### PR TITLE
Proactively informing observers when shutting down

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+target/
+*.iml
+.idea

--- a/rapid/src/main/java/com/vrg/rapid/Cluster.java
+++ b/rapid/src/main/java/com/vrg/rapid/Cluster.java
@@ -140,10 +140,12 @@ public final class Cluster {
     }
 
     /**
-     * Gracefully leaves the cluster by informing observers of the intent.
+     * Gracefully leaves the cluster by informing observers of the intent and then shuts down the entire system
      */
-    public void leave() {
+    public void leaveGracefully() {
+        LOG.debug("Leaving the membership group and shutting down");
         membershipService.leave();
+        shutdown();
     }
 
     /**

--- a/rapid/src/main/java/com/vrg/rapid/Cluster.java
+++ b/rapid/src/main/java/com/vrg/rapid/Cluster.java
@@ -77,6 +77,7 @@ public final class Cluster {
     private final IMessagingServer rpcServer;
     private final SharedResources sharedResources;
     private final Endpoint listenAddress;
+    private boolean hasShutdown = false;
 
     private Cluster(final IMessagingServer rpcServer,
                     final MembershipService membershipService,
@@ -92,8 +93,12 @@ public final class Cluster {
      * Returns the list of endpoints currently in the membership set.
      *
      * @return list of endpoints in the membership set
+     * @throws IllegalStateException when trying to get the memberlist after shutting down
      */
     public List<Endpoint> getMemberlist() {
+        if (hasShutdown) {
+            throw new IllegalStateException("Can't access the memberlist after having shut down");
+        }
         return membershipService.getMembershipView();
     }
 
@@ -101,8 +106,12 @@ public final class Cluster {
      * Returns the number of endpoints currently in the membership set.
      *
      * @return the number of endpoints in the membership set
+     * @throws IllegalStateException when trying to get the membership size after shutting down
      */
     public int getMembershipSize() {
+        if (hasShutdown) {
+            throw new IllegalStateException("Can't access the memberlist after having shut down");
+        }
         return membershipService.getMembershipSize();
     }
 
@@ -110,8 +119,12 @@ public final class Cluster {
      * Returns the list of endpoints currently in the membership set.
      *
      * @return list of endpoints in the membership set
+     * @throws IllegalStateException when trying to get the cluster metadata after shutting down
      */
     public Map<String, Metadata> getClusterMetadata() {
+        if (hasShutdown) {
+            throw new IllegalStateException("Can't access the memberlist after having shut down");
+        }
         return membershipService.getMetadata();
     }
 
@@ -134,6 +147,7 @@ public final class Cluster {
         rpcServer.shutdown();
         membershipService.shutdown();
         sharedResources.shutdown();
+        this.hasShutdown = true;
     }
 
     public static class Builder {

--- a/rapid/src/main/java/com/vrg/rapid/Cluster.java
+++ b/rapid/src/main/java/com/vrg/rapid/Cluster.java
@@ -140,7 +140,14 @@ public final class Cluster {
     }
 
     /**
-     * Shutdown the RpcServer
+     * Gracefully leaves the cluster by informing observers of the intent.
+     */
+    public void leave() {
+        membershipService.leave();
+    }
+
+    /**
+     * Shuts down the entire system
      */
     public void shutdown() {
         LOG.debug("Shutting down RpcServer and MembershipService");

--- a/rapid/src/main/java/com/vrg/rapid/MembershipService.java
+++ b/rapid/src/main/java/com/vrg/rapid/MembershipService.java
@@ -508,13 +508,9 @@ public final class MembershipService {
      * Shuts down all the executors.
      */
     void shutdown() {
-        try {
-            leave();
-        } finally {
-            alertBatcherJob.cancel(true);
-            failureDetectorJobs.forEach(k -> k.cancel(true));
-            messagingClient.shutdown();
-        }
+        alertBatcherJob.cancel(true);
+        failureDetectorJobs.forEach(k -> k.cancel(true));
+        messagingClient.shutdown();
     }
 
     /**

--- a/rapid/src/main/java/com/vrg/rapid/MembershipService.java
+++ b/rapid/src/main/java/com/vrg/rapid/MembershipService.java
@@ -514,7 +514,6 @@ public final class MembershipService {
             alertBatcherJob.cancel(true);
             failureDetectorJobs.forEach(k -> k.cancel(true));
             messagingClient.shutdown();
-            membershipView.reset();
         }
     }
 

--- a/rapid/src/main/java/com/vrg/rapid/MembershipView.java
+++ b/rapid/src/main/java/com/vrg/rapid/MembershipView.java
@@ -406,29 +406,6 @@ final class MembershipView {
         }
     }
 
-    /**
-     * Resets the state of the membership view
-     */
-
-    void reset() {
-        rwLock.readLock().lock();
-        try {
-            identifiersSeen.clear();
-            rings.clear();
-            addressComparators.clear();
-            for (int k = 0; k < K; k++) {
-                final Utils.AddressComparator comparatorWithSeed = Utils.AddressComparator.getComparatorWithSeed(k);
-                this.addressComparators.add(comparatorWithSeed);
-                this.rings.add(new TreeSet<>(comparatorWithSeed));
-            }
-            this.currentConfiguration = new Configuration(identifiersSeen, rings.get(0));
-            this.currentConfigurationId = -1;
-            this.shouldUpdateConfigurationId = true;
-        } finally {
-            rwLock.readLock().unlock();
-        }
-    }
-
     private static final class NodeIdComparator implements Comparator<NodeId>, Serializable {
         private static final long serialVersionUID = -4891729395L;
         private static final NodeIdComparator INSTANCE = new NodeIdComparator();

--- a/rapid/src/main/java/com/vrg/rapid/MembershipView.java
+++ b/rapid/src/main/java/com/vrg/rapid/MembershipView.java
@@ -406,6 +406,29 @@ final class MembershipView {
         }
     }
 
+    /**
+     * Resets the state of the membership view
+     */
+
+    void reset() {
+        rwLock.readLock().lock();
+        try {
+            identifiersSeen.clear();
+            rings.clear();
+            addressComparators.clear();
+            for (int k = 0; k < K; k++) {
+                final Utils.AddressComparator comparatorWithSeed = Utils.AddressComparator.getComparatorWithSeed(k);
+                this.addressComparators.add(comparatorWithSeed);
+                this.rings.add(new TreeSet<>(comparatorWithSeed));
+            }
+            this.currentConfiguration = new Configuration(identifiersSeen, rings.get(0));
+            this.currentConfigurationId = -1;
+            this.shouldUpdateConfigurationId = true;
+        } finally {
+            rwLock.readLock().unlock();
+        }
+    }
+
     private static final class NodeIdComparator implements Comparator<NodeId>, Serializable {
         private static final long serialVersionUID = -4891729395L;
         private static final NodeIdComparator INSTANCE = new NodeIdComparator();

--- a/rapid/src/main/proto/rapid.proto
+++ b/rapid/src/main/proto/rapid.proto
@@ -30,6 +30,7 @@ message RapidRequest
         Phase1bMessage phase1bMessage = 7;
         Phase2aMessage phase2aMessage = 8;
         Phase2bMessage phase2bMessage = 9;
+        LeaveMessage leaveMessage = 10;
    }
 }
 
@@ -178,6 +179,12 @@ message Metadata
     map<string, bytes> metadata = 1;
 }
 
+// ******* Leave protocol *******
+
+message LeaveMessage
+{
+    Endpoint sender = 1;
+}
 
 // ******* Used by simple probing failure detector *******
 

--- a/rapid/src/test/java/com/vrg/rapid/ClusterTest.java
+++ b/rapid/src/test/java/com/vrg/rapid/ClusterTest.java
@@ -515,8 +515,7 @@ public class ClusterTest {
             extendCluster(1, seedEndpoint);
             waitAndVerifyAgreement(i + 2, 5, 1000);
         }
-        instances.get(seedEndpoint).leave();
-        instances.get(seedEndpoint).shutdown();
+        instances.get(seedEndpoint).leaveGracefully();
         instances.remove(seedEndpoint);
         waitAndVerifyAgreement(numNodes, 2, 1000);
     }

--- a/rapid/src/test/java/com/vrg/rapid/ClusterTest.java
+++ b/rapid/src/test/java/com/vrg/rapid/ClusterTest.java
@@ -467,6 +467,7 @@ public class ClusterTest {
      */
     @Test(timeout = 30000)
     public void testRejoinMultipleNodes() throws IOException, InterruptedException {
+        useFastFailureDetectionTimeouts();
         final Endpoint seedEndpoint = Utils.hostFromParts("127.0.0.1", basePort);
         final int numNodes = 30;
         final int failNodes = 5;
@@ -484,9 +485,9 @@ public class ClusterTest {
                         final Cluster cluster = instances.remove(leavingEndpoint);
                         try {
                             cluster.shutdown();
-                            waitAndVerifyAgreement(numNodes - failNodes, 20, 1000);
+                            waitAndVerifyAgreement(numNodes - failNodes, 20, 500);
                             extendCluster(leavingEndpoint, seedEndpoint);
-                            waitAndVerifyAgreement(numNodes, 20, 1000);
+                            waitAndVerifyAgreement(numNodes, 20, 500);
                         } catch (final InterruptedException e) {
                             fail();
                         }
@@ -497,7 +498,7 @@ public class ClusterTest {
             });
         }
         latch.await();
-        waitAndVerifyAgreement(numNodes, 20, 1000);
+        waitAndVerifyAgreement(numNodes, 10, 250);
         executor.shutdownNow();
     }
 
@@ -514,6 +515,7 @@ public class ClusterTest {
             extendCluster(1, seedEndpoint);
             waitAndVerifyAgreement(i + 2, 5, 1000);
         }
+        instances.get(seedEndpoint).leave();
         instances.get(seedEndpoint).shutdown();
         instances.remove(seedEndpoint);
         waitAndVerifyAgreement(numNodes, 2, 1000);

--- a/rapid/src/test/java/com/vrg/rapid/ClusterTest.java
+++ b/rapid/src/test/java/com/vrg/rapid/ClusterTest.java
@@ -308,7 +308,7 @@ public class ClusterTest {
         final Set<Endpoint> failingNodes = getRandomHosts(numFailingNodes);
         staticFds.values().forEach(e -> e.addFailedNodes(failingNodes));
         failingNodes.forEach(h -> instances.remove(h).shutdown());
-        waitAndVerifyAgreement(numNodes - failingNodes.size(), 20, 1000);
+        waitAndVerifyAgreement(numNodes - failingNodes.size(), 20, 1500);
         // Nodes do not actually shutdown(), but are detected faulty. The faulty nodes have active
         // cluster instances and identify themselves as kicked out.
         verifyNumClusterInstances(numNodes - failingNodes.size());
@@ -467,7 +467,6 @@ public class ClusterTest {
      */
     @Test(timeout = 30000)
     public void testRejoinMultipleNodes() throws IOException, InterruptedException {
-        useFastFailureDetectionTimeouts();
         final Endpoint seedEndpoint = Utils.hostFromParts("127.0.0.1", basePort);
         final int numNodes = 30;
         final int failNodes = 5;
@@ -485,9 +484,9 @@ public class ClusterTest {
                         final Cluster cluster = instances.remove(leavingEndpoint);
                         try {
                             cluster.shutdown();
-                            waitAndVerifyAgreement(numNodes - failNodes, 20, 500);
+                            waitAndVerifyAgreement(numNodes - failNodes, 20, 1000);
                             extendCluster(leavingEndpoint, seedEndpoint);
-                            waitAndVerifyAgreement(numNodes, 20, 500);
+                            waitAndVerifyAgreement(numNodes, 20, 1000);
                         } catch (final InterruptedException e) {
                             fail();
                         }
@@ -498,7 +497,7 @@ public class ClusterTest {
             });
         }
         latch.await();
-        waitAndVerifyAgreement(numNodes, 10, 250);
+        waitAndVerifyAgreement(numNodes, 20, 1000);
         executor.shutdownNow();
     }
 

--- a/rapid/src/test/java/com/vrg/rapid/ClusterTest.java
+++ b/rapid/src/test/java/com/vrg/rapid/ClusterTest.java
@@ -503,6 +503,24 @@ public class ClusterTest {
     }
 
     /**
+     * Test a node proactively leaving the cluster
+     */
+    @Test(timeout = 30000)
+    public void testLeaving() throws IOException, InterruptedException {
+        final int numNodes = 10;
+        final Endpoint seedEndpoint = Utils.hostFromParts("127.0.0.1", basePort);
+        createCluster(1, seedEndpoint); // Only bootstrap a seed.
+        verifyCluster(1);
+        for (int i = 0; i < numNodes; i++) {
+            extendCluster(1, seedEndpoint);
+            waitAndVerifyAgreement(i + 2, 5, 1000);
+        }
+        instances.get(seedEndpoint).shutdown();
+        instances.remove(seedEndpoint);
+        waitAndVerifyAgreement(numNodes, 2, 1000);
+    }
+
+    /**
      * Creates a cluster of size {@code numNodes} with a seed {@code seedEndpoint}.
      *
      * @param numNodes cluster size


### PR DESCRIPTION
Rather than waiting for edge failure detection to kick in when a cluster has been shut down, this change proactively informs the observers of a node with a new `Leaving` message. In turn the observers the trigger edge failure alerting immediately.