### PR TITLE
Performance optimization

### DIFF
--- a/rapid/src/main/java/com/vrg/rapid/MembershipService.java
+++ b/rapid/src/main/java/com/vrg/rapid/MembershipService.java
@@ -71,7 +71,7 @@ import java.util.stream.Collectors;
 @NotThreadSafe
 public final class MembershipService {
     private static final Logger LOG = LoggerFactory.getLogger(MembershipService.class);
-    private static final int BATCHING_WINDOW_IN_MS = 100;
+    static final int BATCHING_WINDOW_IN_MS = 100;
     private static final int DEFAULT_FAILURE_DETECTOR_INITIAL_DELAY_IN_MS = 0;
     static final int DEFAULT_FAILURE_DETECTOR_INTERVAL_IN_MS = 1000;
     private static final int LEAVE_MESSAGE_TIMEOUT = 1500;
@@ -144,7 +144,7 @@ public final class MembershipService {
         // Schedule background jobs
         this.backgroundTasksExecutor = sharedResources.getScheduledTasksExecutor();
         alertBatcherJob = this.backgroundTasksExecutor.scheduleAtFixedRate(new AlertBatcher(),
-                0, BATCHING_WINDOW_IN_MS, TimeUnit.MILLISECONDS);
+                0, settings.getBatchingWindowInMs(), TimeUnit.MILLISECONDS);
 
         this.broadcaster.setMembership(membershipView.getRing(0));
         // this::edgeFailureNotification is invoked by the failure detector whenever an edge
@@ -589,15 +589,14 @@ public final class MembershipService {
      * Batches outgoing AlertMessages into a single BatchAlertMessage.
      */
     private class AlertBatcher implements Runnable {
-        private static final int BATCH_WINDOW_IN_MS = 100;
 
         @Override
         public void run() {
             batchSchedulerLock.lock();
             try {
-                // Wait one BATCH_WINDOW_IN_MS since last add before sending out
+                // Wait one BATCHING_WINDOW_IN_MS since last add before sending out
                 if (!sendQueue.isEmpty() && lastEnqueueTimestamp > 0
-                        && (System.currentTimeMillis() - lastEnqueueTimestamp) > BATCH_WINDOW_IN_MS) {
+                        && (System.currentTimeMillis() - lastEnqueueTimestamp) > settings.getBatchingWindowInMs()) {
                     LOG.trace("Scheduler is sending out {} messages", sendQueue.size());
                     final ArrayList<AlertMessage> messages = new ArrayList<>(sendQueue.size());
                     final int numDrained = sendQueue.drainTo(messages);
@@ -718,5 +717,7 @@ public final class MembershipService {
 
     interface ISettings {
         int getFailureDetectorIntervalInMs();
+
+        int getBatchingWindowInMs();
     }
 }

--- a/rapid/src/main/java/com/vrg/rapid/MembershipView.java
+++ b/rapid/src/main/java/com/vrg/rapid/MembershipView.java
@@ -31,6 +31,9 @@ import java.util.NavigableSet;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.HashMap;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -46,6 +49,7 @@ final class MembershipView {
     @GuardedBy("rwLock") private final ArrayList<Utils.AddressComparator> addressComparators;
     @GuardedBy("rwLock") private final ArrayList<NavigableSet<Endpoint>> rings;
     @GuardedBy("rwLock") private final Set<NodeId> identifiersSeen = new TreeSet<>(NodeIdComparator.INSTANCE);
+    @GuardedBy("rwLock") private final Map<Endpoint, List<Endpoint>> cachedObservers = new HashMap<>();
     @GuardedBy("rwLock") private long currentConfigurationId = -1;
     @GuardedBy("rwLock") private Configuration currentConfiguration;
     @GuardedBy("rwLock") private boolean shouldUpdateConfigurationId = true;
@@ -129,11 +133,24 @@ final class MembershipView {
                 throw new NodeAlreadyInRingException(node);
             }
 
+            final Set<Endpoint> affectedSubjects = new HashSet<>();
+
             for (int k = 0; k < K; k++) {
-                rings.get(k).add(node);
+                final NavigableSet<Endpoint> endpoints = rings.get(k);
+                endpoints.add(node);
+
+                final Endpoint subject = endpoints.lower(node);
+                if (subject != null) {
+                    affectedSubjects.add(subject);
+                }
+            }
+
+            for (final Endpoint subject : affectedSubjects) {
+                cachedObservers.put(subject, computeObserversOf(subject));
             }
 
             identifiersSeen.add(nodeId);
+
             shouldUpdateConfigurationId = true;
         } finally {
             rwLock.writeLock().unlock();
@@ -154,9 +171,24 @@ final class MembershipView {
                 throw new NodeNotInRingException(node);
             }
 
+            final Set<Endpoint> affectedSubjects = new HashSet<>();
+
             for (int k = 0; k < K; k++) {
-                rings.get(k).remove(node);
+                final NavigableSet<Endpoint> endpoints = rings.get(k);
+
+                final Endpoint oldSubject = endpoints.lower(node);
+                if (oldSubject != null) {
+                    affectedSubjects.add(oldSubject);
+                }
+
+                endpoints.remove(node);
+
                 addressComparators.get(k).removeEndpoint(node);
+                cachedObservers.remove(node);
+            }
+
+            for (final Endpoint subject : affectedSubjects) {
+                cachedObservers.put(subject, computeObserversOf(subject));
             }
 
             shouldUpdateConfigurationId = true;
@@ -179,28 +211,48 @@ final class MembershipView {
             if (!rings.get(0).contains(node)) {
                 throw new NodeNotInRingException(node);
             }
-
-            if (rings.get(0).size() <= 1) {
-                return Collections.emptyList();
+            if (!cachedObservers.containsKey(node)) {
+                cachedObservers.put(node, computeObserversOf(node));
             }
-
-            final List<Endpoint> observers = new ArrayList<>();
-
-            for (int k = 0; k < K; k++) {
-                final NavigableSet<Endpoint> list = rings.get(k);
-                final Endpoint successor = list.higher(node);
-                if (successor == null) {
-                    observers.add(list.first());
-                }
-                else {
-                    observers.add(successor);
-                }
-            }
-            return observers;
+            return cachedObservers.get(node);
         } finally {
             rwLock.readLock().unlock();
         }
     }
+
+    /**
+     * Computes the set of observers for {@code node}.
+     * Only call this from a (thread-)safe place!
+     *
+     * @param node input node
+     * @return the set of observers for {@code node}
+     * @throws NodeNotInRingException thrown if {@code node} is not in the ring
+     */
+    private List<Endpoint> computeObserversOf(final Endpoint node) {
+        Objects.requireNonNull(node);
+        if (!rings.get(0).contains(node)) {
+            throw new NodeNotInRingException(node);
+        }
+
+        if (rings.get(0).size() <= 1) {
+            return Collections.emptyList();
+        }
+
+        final List<Endpoint> observers = new ArrayList<>();
+
+        for (int k = 0; k < K; k++) {
+            final NavigableSet<Endpoint> list = rings.get(k);
+            final Endpoint successor = list.higher(node);
+            if (successor == null) {
+                observers.add(list.first());
+            }
+            else {
+                observers.add(successor);
+            }
+        }
+        return observers;
+    }
+
 
     /**
      * Returns the set of nodes monitored by {@code node}

--- a/rapid/src/main/java/com/vrg/rapid/MembershipView.java
+++ b/rapid/src/main/java/com/vrg/rapid/MembershipView.java
@@ -149,7 +149,7 @@ final class MembershipView {
             allNodes.add(node);
 
             for (final Endpoint subject : affectedSubjects) {
-                cachedObservers.put(subject, computeObserversOf(subject));
+                cachedObservers.remove(subject);
             }
 
             identifiersSeen.add(nodeId);
@@ -192,7 +192,7 @@ final class MembershipView {
             allNodes.remove(node);
 
             for (final Endpoint subject : affectedSubjects) {
-                cachedObservers.put(subject, computeObserversOf(subject));
+                cachedObservers.remove(subject);
             }
 
             shouldUpdateConfigurationId = true;

--- a/rapid/src/main/java/com/vrg/rapid/MultiNodeCutDetector.java
+++ b/rapid/src/main/java/com/vrg/rapid/MultiNodeCutDetector.java
@@ -43,7 +43,7 @@ final class MultiNodeCutDetector {
     @GuardedBy("lock") private int proposalCount = 0;
     @GuardedBy("lock") private int updatesInProgress = 0;
     @GuardedBy("lock") private final Map<Endpoint, Map<Integer, Endpoint>> reportsPerHost;
-    @GuardedBy("lock") private final ArrayList<Endpoint> proposal = new ArrayList<>();
+    @GuardedBy("lock") private final Set<Endpoint> proposal = new HashSet<>();
     @GuardedBy("lock") private final Set<Endpoint> preProposal = new HashSet<>();
     @GuardedBy("lock") private boolean seenLinkDownEvents = false;
     private final Object lock = new Object();
@@ -159,7 +159,7 @@ final class MultiNodeCutDetector {
                 }
             }
 
-            return ImmutableList.copyOf(proposalsToReturn);
+            return Collections.unmodifiableList(proposalsToReturn);
         }
     }
 

--- a/rapid/src/main/java/com/vrg/rapid/Settings.java
+++ b/rapid/src/main/java/com/vrg/rapid/Settings.java
@@ -12,6 +12,7 @@ public final class Settings implements GrpcClient.ISettings, MembershipService.I
     private int grpcJoinTimeoutMs = GrpcClient.DEFAULT_GRPC_JOIN_TIMEOUT;
     private int grpcProbeTimeoutMs = GrpcClient.DEFAULT_GRPC_PROBE_TIMEOUT;
     private int failureDetectorIntervalInMs = MembershipService.DEFAULT_FAILURE_DETECTOR_INTERVAL_IN_MS;
+    private int batchingWindowInMs = MembershipService.BATCHING_WINDOW_IN_MS;
 
     /*
      * Settings from GrpcClient.ISettings
@@ -72,5 +73,14 @@ public final class Settings implements GrpcClient.ISettings, MembershipService.I
 
     public void setFailureDetectorIntervalInMs(final int failureDetectorIntervalInMs) {
         this.failureDetectorIntervalInMs = failureDetectorIntervalInMs;
+    }
+
+    @Override
+    public int getBatchingWindowInMs() {
+        return this.batchingWindowInMs;
+    }
+
+    public void setBatchingWindowInMs(final int batchingWindowInMs) {
+        this.batchingWindowInMs = batchingWindowInMs;
     }
 }

--- a/rapid/src/main/java/com/vrg/rapid/Utils.java
+++ b/rapid/src/main/java/com/vrg/rapid/Utils.java
@@ -190,7 +190,7 @@ final class Utils {
         private static final long serialVersionUID = -4891729390L;
         private static final Map<Integer, AddressComparator> INSTANCES = new HashMap<>();
         private final LongHashFunction hashFunction;
-        private final Map<ComparableEndpoint, Long> hashCache;
+        private final Map<Endpoint, Long> hashCache;
 
         AddressComparator(final int seed) {
             this.hashFunction = LongHashFunction.xx(seed);
@@ -199,11 +199,8 @@ final class Utils {
 
         @Override
         public final int compare(final Endpoint c1, final Endpoint c2) {
-            final ComparableEndpoint ce1 = new ComparableEndpoint(c1);
-            final ComparableEndpoint ce2 = new ComparableEndpoint(c2);
-
-            final long hash1 = hashCache.computeIfAbsent(ce1, this::computeHash);
-            final long hash2 = hashCache.computeIfAbsent(ce2, this::computeHash);
+            final long hash1 = hashCache.computeIfAbsent(c1, this::computeHash);
+            final long hash2 = hashCache.computeIfAbsent(c2, this::computeHash);
             return Long.compare(hash1, hash2);
         }
 
@@ -211,51 +208,12 @@ final class Utils {
             return INSTANCES.computeIfAbsent(seed, AddressComparator::new);
         }
 
-        private long computeHash(final ComparableEndpoint comparable) {
-            return hashFunction.hashBytes(comparable.getEndpoint().getHostnameBytes().asReadOnlyByteBuffer()) * 31
-                    + hashFunction.hashInt(comparable.getEndpoint().getPort());
+        private long computeHash(final Endpoint endpoint) {
+            return hashFunction.hashChars(endpoint.getHostname()) * 31 + hashFunction.hashInt(endpoint.getPort());
         }
 
         void removeEndpoint(final Endpoint endpoint) {
-            hashCache.remove(new ComparableEndpoint(endpoint));
+            hashCache.remove(endpoint);
         }
-    }
-
-    static final class ComparableEndpoint implements Serializable {
-        private static final long serialVersionUID = -1891759320L;
-
-        final Endpoint endpoint;
-
-        public ComparableEndpoint(final Endpoint endpoint) {
-            this.endpoint = endpoint;
-        }
-
-        @Override
-        public boolean equals(final Object obj) {
-            if (obj == this) {
-                return true;
-            }
-            if (!(obj instanceof ComparableEndpoint)) {
-                return super.equals(obj);
-            }
-            final ComparableEndpoint other = (ComparableEndpoint) obj;
-
-            return endpoint.getHostnameBytes().equals(other.getEndpoint().getHostnameBytes())
-                    && endpoint.getPort() == other.getEndpoint().getPort();
-        }
-
-        @Override
-        public int hashCode() {
-            int hash = 41;
-            hash = (17 * hash) + endpoint.getHostnameBytes().hashCode();
-            hash = (37 * hash) + endpoint.getPort();
-            return hash;
-        }
-
-        public Endpoint getEndpoint() {
-            return this.endpoint;
-        }
-
-
     }
 }


### PR DESCRIPTION
A lot of time spent in `MultinodeCutDetector.invalidateFailingEdges` was caused by calling `contains` on an `ArrayList`, which is slow with many nodes:

![arraylist](https://user-images.githubusercontent.com/459669/77141672-01fcf500-6a7e-11ea-8112-879551fc36f8.png)

A lot of time spent in `MultinodeCutDetector.invalidateFailingEdges` was directly related to computing observers for each alert, which takes a long time with many nodes:

![observer-perf](https://user-images.githubusercontent.com/459669/77141590-bf3b1d00-6a7d-11ea-9e91-1cbb91a5b556.png)

