### PR TITLE
Endpoint performance and memory pressure optimization

### DIFF
--- a/examples/src/main/java/com/vrg/standalone/AgentWithNettyMessaging.java
+++ b/examples/src/main/java/com/vrg/standalone/AgentWithNettyMessaging.java
@@ -14,6 +14,7 @@
 package com.vrg.standalone;
 
 import com.google.common.net.HostAndPort;
+import com.google.protobuf.ByteString;
 import com.vrg.rapid.Cluster;
 import com.vrg.rapid.messaging.impl.NettyClientServer;
 import com.vrg.rapid.pb.Endpoint;
@@ -45,7 +46,7 @@ public class AgentWithNettyMessaging extends StandaloneAgent {
     @Override
     public void startCluster() throws IOException, InterruptedException {
         final Endpoint endpoint = Endpoint.newBuilder()
-                                          .setHostname(listenAddress.getHost())
+                                          .setHostname(ByteString.copyFromUtf8(listenAddress.getHost()))
                                           .setPort(listenAddress.getPort()).build();
 
         // To use your own messaging implementation with Rapid, supply an instance each of IMessagingClient

--- a/rapid/src/main/java/com/vrg/rapid/MembershipService.java
+++ b/rapid/src/main/java/com/vrg/rapid/MembershipService.java
@@ -269,7 +269,8 @@ public final class MembershipService {
                     responseBuilder = responseBuilder.setStatusCode(JoinStatusCode.SAFE_TO_JOIN)
                             .addAllEndpoints(configuration.endpoints)
                             .addAllIdentifiers(configuration.nodeIds)
-                            .putAllClusterMetadata(metadataManager.getAllMetadata());
+                            .addAllMetadataKeys(metadataManager.getAllMetadata().keySet())
+                            .addAllMetadataValues(metadataManager.getAllMetadata().values());
                 } else {
                     responseBuilder = responseBuilder.setStatusCode(JoinStatusCode.CONFIG_CHANGED);
                     LOG.info("Returning CONFIG_CHANGED for {sender:{}, config:{}, size:{}}",
@@ -501,7 +502,7 @@ public final class MembershipService {
      *
      * @return list of endpoints in the membership view
      */
-    Map<String, Metadata> getMetadata() {
+    Map<Endpoint, Metadata> getMetadata() {
         synchronized (membershipUpdateLock) {
             return metadataManager.getAllMetadata();
         }
@@ -701,7 +702,8 @@ public final class MembershipService {
                 .setConfigurationId(configuration.getConfigurationId())
                 .addAllEndpoints(configuration.endpoints)
                 .addAllIdentifiers(configuration.nodeIds)
-                .putAllClusterMetadata(metadataManager.getAllMetadata())
+                .addAllMetadataKeys(metadataManager.getAllMetadata().keySet())
+                .addAllMetadataValues(metadataManager.getAllMetadata().values())
                 .build();
 
         // Send out responses to all the nodes waiting to join.

--- a/rapid/src/main/java/com/vrg/rapid/MembershipView.java
+++ b/rapid/src/main/java/com/vrg/rapid/MembershipView.java
@@ -540,7 +540,7 @@ final class MembershipView {
                 hash = hash * 37 + HASH_FUNCTION.hashLong(id.getLow());
             }
             for (final Endpoint endpoint : endpoints) {
-                hash = hash * 37 + HASH_FUNCTION.hashChars(endpoint.getHostname());
+                hash = hash * 37 + HASH_FUNCTION.hashBytes(endpoint.getHostname().asReadOnlyByteBuffer());
                 hash = hash * 37 + HASH_FUNCTION.hashInt(endpoint.getPort());
             }
             return hash;

--- a/rapid/src/main/java/com/vrg/rapid/MetadataManager.java
+++ b/rapid/src/main/java/com/vrg/rapid/MetadataManager.java
@@ -14,7 +14,6 @@
 
 package com.vrg.rapid;
 
-import com.google.common.collect.ImmutableMap;
 import com.vrg.rapid.pb.Endpoint;
 import com.vrg.rapid.pb.Metadata;
 import io.grpc.ExperimentalApi;
@@ -65,11 +64,7 @@ final class MetadataManager {
     /**
      * Get the list of all node tags. This is shared with joining nodes when they bootstrap.
      */
-    Map<String, Metadata> getAllMetadata() {
-        // XXX: Not happy with the back and forth conversion here. We should not require conversions
-        // between Endpoint and strings when crossing over from protobufs to rapid and vice-versa.
-        final ImmutableMap.Builder<String, Metadata> stringMap = ImmutableMap.builder();
-        roleMap.forEach((k, v) -> stringMap.put(k.getHostname() + ":" + k.getPort(), v));
-        return stringMap.build();
+    Map<Endpoint, Metadata> getAllMetadata() {
+        return roleMap;
     }
 }

--- a/rapid/src/main/java/com/vrg/rapid/NodeStatusChange.java
+++ b/rapid/src/main/java/com/vrg/rapid/NodeStatusChange.java
@@ -48,6 +48,6 @@ public class NodeStatusChange {
 
     @Override
     public String toString() {
-        return endpoint.getHostname() + ":" + endpoint.getPort() + ":" + status + ":" + metadata;
+        return endpoint.getHostname().toStringUtf8() + ":" + endpoint.getPort() + ":" + status + ":" + metadata;
     }
 }

--- a/rapid/src/main/java/com/vrg/rapid/SharedResources.java
+++ b/rapid/src/main/java/com/vrg/rapid/SharedResources.java
@@ -119,7 +119,7 @@ public class SharedResources {
      * use Netty's DefaultThreadFactory.
      */
     private DefaultThreadFactory newFastLocalThreadFactory(final String poolName, final Endpoint address) {
-        return new DefaultThreadFactory(poolName + "-" + address.getHostname() + ":"
+        return new DefaultThreadFactory(poolName + "-" + address.getHostname().toStringUtf8() + ":"
                 + address.getPort(), true);
     }
 
@@ -127,7 +127,7 @@ public class SharedResources {
      * Standard threads with an exception handler.
      */
     private ThreadFactory newNamedThreadFactory(final String poolName, final Endpoint address) {
-        final String namePrefix = poolName + "-" + address.getHostname() + ":" + address.getPort();
+        final String namePrefix = poolName + "-" + address.getHostname().toStringUtf8() + ":" + address.getPort();
         return new ThreadFactoryBuilder()
                 .setNameFormat(namePrefix + "-%d")
                 .setDaemon(true)

--- a/rapid/src/main/java/com/vrg/rapid/Utils.java
+++ b/rapid/src/main/java/com/vrg/rapid/Utils.java
@@ -14,6 +14,7 @@
 package com.vrg.rapid;
 
 import com.google.common.net.HostAndPort;
+import com.google.protobuf.ByteString;
 import com.google.protobuf.GeneratedMessageV3;
 import com.google.protobuf.TextFormat;
 import com.vrg.rapid.pb.BatchedAlertMessage;
@@ -62,9 +63,9 @@ final class Utils {
      */
     static Endpoint hostFromString(final String hostString) {
         final HostAndPort hostAndPort = HostAndPort.fromString(hostString);    // Validates input
-        return Endpoint.newBuilder().setHostname(hostAndPort.getHost())
-                                           .setPort(hostAndPort.getPort())
-                                           .build();
+        return Endpoint.newBuilder().setHostname(ByteString.copyFromUtf8(hostAndPort.getHost()))
+                                    .setPort(hostAndPort.getPort())
+                                    .build();
     }
 
     /**
@@ -72,7 +73,8 @@ final class Utils {
      */
     static Endpoint hostFromParts(final String hostname, final int port) {
         final HostAndPort hostAndPort = HostAndPort.fromParts(hostname, port); // Validates input
-        return Endpoint.newBuilder().setHostname(hostAndPort.getHost())
+        return Endpoint.newBuilder()
+                .setHostname(ByteString.copyFromUtf8(hostAndPort.getHost()))
                 .setPort(hostAndPort.getPort())
                 .build();
     }
@@ -91,7 +93,8 @@ final class Utils {
         @Override
         public String toString() {
             if (protobufObject instanceof Endpoint) {
-                return ((Endpoint) protobufObject).getHostname() + ":" + ((Endpoint) protobufObject).getPort();
+                return ((Endpoint) protobufObject).getHostname().toStringUtf8()
+                        + ":" + ((Endpoint) protobufObject).getPort();
             }
             else {
                 return TextFormat.shortDebugString(protobufObject);
@@ -222,7 +225,8 @@ final class Utils {
         }
 
         private long computeHash(final Endpoint endpoint) {
-            return hashFunction.hashChars(endpoint.getHostname()) * 31 + hashFunction.hashInt(endpoint.getPort());
+            return hashFunction.hashBytes(endpoint.getHostname().asReadOnlyByteBuffer()) * 31
+                    + hashFunction.hashInt(endpoint.getPort());
         }
 
         void removeEndpoint(final Endpoint endpoint) {

--- a/rapid/src/main/java/com/vrg/rapid/messaging/impl/GrpcClient.java
+++ b/rapid/src/main/java/com/vrg/rapid/messaging/impl/GrpcClient.java
@@ -171,7 +171,7 @@ public class GrpcClient implements IMessagingClient {
                     .build();
         } else {
             channel = NettyChannelBuilder
-                    .forAddress(remote.getHostname(), remote.getPort())
+                    .forAddress(remote.getHostname().toStringUtf8(), remote.getPort())
                     .executor(grpcExecutor)
                     .eventLoopGroup(eventLoopGroup)
                     .usePlaintext(true)

--- a/rapid/src/main/java/com/vrg/rapid/messaging/impl/GrpcServer.java
+++ b/rapid/src/main/java/com/vrg/rapid/messaging/impl/GrpcServer.java
@@ -137,7 +137,9 @@ public class GrpcServer extends MembershipServiceGrpc.MembershipServiceImplBase 
                     .build()
                     .start();
         } else {
-            server = NettyServerBuilder.forAddress(new InetSocketAddress(address.getHostname(), address.getPort()))
+            server = NettyServerBuilder.forAddress(
+                        new InetSocketAddress(address.getHostname().toStringUtf8(), address.getPort())
+                    )
                     .workerEventLoopGroup(eventLoopGroup)
                     .addService(this)
                     .executor(grpcExecutor)

--- a/rapid/src/main/java/com/vrg/rapid/messaging/impl/NettyClientServer.java
+++ b/rapid/src/main/java/com/vrg/rapid/messaging/impl/NettyClientServer.java
@@ -151,7 +151,8 @@ public class NettyClientServer implements IMessagingClient, IMessagingServer {
                 .option(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT)
                 .childHandler(new ServerChannelInitializer(serverHandler));
         try {
-            serverChannel = serverBootstrap.bind(listenAddress.getHostname(), listenAddress.getPort()).sync();
+            serverChannel = serverBootstrap.bind(listenAddress.getHostname().toStringUtf8(),
+                    listenAddress.getPort()).sync();
         } catch (final InterruptedException e) {
             Thread.currentThread().interrupt();
             LOG.error("Could not start server {}", e);
@@ -318,7 +319,7 @@ public class NettyClientServer implements IMessagingClient, IMessagingServer {
         @Override
         public ChannelFuture load(@Nonnull final Endpoint endpoint) throws Exception {
             // Connect to remote endpoint
-            return clientBootstrap.connect(endpoint.getHostname(), endpoint.getPort()).sync();
+            return clientBootstrap.connect(endpoint.getHostname().toStringUtf8(), endpoint.getPort()).sync();
         }
     }
 

--- a/rapid/src/main/proto/rapid.proto
+++ b/rapid/src/main/proto/rapid.proto
@@ -12,7 +12,7 @@ service MembershipService {
 
 message Endpoint
 {
-    string hostname = 1;
+    bytes hostname = 1;
     int32 port = 2;
 }
 
@@ -78,7 +78,8 @@ message JoinResponse
    int64 configurationId = 3;
    repeated Endpoint endpoints = 4;
    repeated NodeId identifiers = 5;
-   map<string, Metadata> clusterMetadata = 6;
+   repeated Endpoint metadataKeys = 6;
+   repeated Metadata metadataValues = 7;
 }
 
 enum JoinStatusCode {

--- a/rapid/src/test/java/com/vrg/rapid/ClusterTest.java
+++ b/rapid/src/test/java/com/vrg/rapid/ClusterTest.java
@@ -446,6 +446,7 @@ public class ClusterTest {
         Cluster cluster = null;
         try {
             cluster = instances.remove(rejoiningEndpoint);
+            assertEquals(9, instances.size());
             cluster.shutdown();
             try {
                 buildCluster(rejoiningEndpoint).join(seedEndpoint);

--- a/rapid/src/test/java/com/vrg/rapid/LoggableTests.java
+++ b/rapid/src/test/java/com/vrg/rapid/LoggableTests.java
@@ -14,6 +14,7 @@
 package com.vrg.rapid;
 
 import com.google.common.collect.ImmutableList;
+import com.google.protobuf.ByteString;
 import com.vrg.rapid.pb.Endpoint;
 import com.vrg.rapid.pb.Phase1bMessage;
 import com.vrg.rapid.pb.Rank;
@@ -44,8 +45,10 @@ public class LoggableTests {
     private Phase1bMessage getMessage() {
         final Rank rank = Rank.newBuilder().setRound(1).setNodeIndex(2).build();
         final List<Endpoint> endpoints =
-                ImmutableList.of(Endpoint.newBuilder().setHostname("127.0.0.1").setPort(50).build(),
-                        Endpoint.newBuilder().setHostname("127.0.0.2").setPort(51).build());
+                ImmutableList.of(Endpoint.newBuilder().setHostname(ByteString.copyFromUtf8("127.0.0.1"))
+                                .setPort(50).build(),
+                        Endpoint.newBuilder().setHostname(ByteString.copyFromUtf8("127.0.0.2"))
+                                .setPort(51).build());
         return Phase1bMessage.newBuilder()
                 .setRnd(rank)
                 .addAllVval(endpoints)

--- a/rapid/src/test/java/com/vrg/rapid/NettyClientServerTest.java
+++ b/rapid/src/test/java/com/vrg/rapid/NettyClientServerTest.java
@@ -15,6 +15,7 @@ package com.vrg.rapid;
 
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.protobuf.ByteString;
 import com.vrg.rapid.messaging.impl.NettyClientServer;
 import com.vrg.rapid.pb.Endpoint;
 import com.vrg.rapid.pb.ProbeMessage;
@@ -40,7 +41,7 @@ public class NettyClientServerTest {
         Cluster serverInstance = null;
         try {
             final int numClients = 100;
-            final Endpoint server = Endpoint.newBuilder().setHostname("127.0.0.1")
+            final Endpoint server = Endpoint.newBuilder().setHostname(ByteString.copyFromUtf8("127.0.0.1"))
                     .setPort(9000).build();
             final SharedResources resources = new SharedResources(server);
             final NettyClientServer serverMessaging = new NettyClientServer(server, resources);
@@ -52,7 +53,7 @@ public class NettyClientServerTest {
             final List<NettyClientServer> ncs = new ArrayList<>();
             for (int i = 0; i < numClients; i++) {
                 final Endpoint clientEp = Endpoint.newBuilder()
-                        .setHostname("127.0.0.1")
+                        .setHostname(ByteString.copyFromUtf8("127.0.0.1"))
                         .setPort(9002 + i).build();
                 ncs.add(new NettyClientServer(clientEp, shared));
             }
@@ -86,7 +87,7 @@ public class NettyClientServerTest {
             final SharedResources resources = new SharedResources(Endpoint.getDefaultInstance());
 
             for (int i = 0; i < numServers; i++) {
-                final Endpoint server = Endpoint.newBuilder().setHostname("127.0.0.1")
+                final Endpoint server = Endpoint.newBuilder().setHostname(ByteString.copyFromUtf8("127.0.0.1"))
                         .setPort(9001 + i).build();
                 final NettyClientServer serverMessaging = new NettyClientServer(server, resources);
                 final Cluster cluster = new Cluster.Builder(server)
@@ -96,11 +97,11 @@ public class NettyClientServerTest {
             }
             final SharedResources resources2 = new SharedResources(Endpoint.getDefaultInstance());
 
-            final Endpoint clientEp = Endpoint.newBuilder().setHostname("127.0.0.1")
+            final Endpoint clientEp = Endpoint.newBuilder().setHostname(ByteString.copyFromUtf8("127.0.0.1"))
                     .setPort(9000).build();
             final NettyClientServer clientMessaging = new NettyClientServer(clientEp, resources2);
             for (int i = 0; i < numServers; i++) {
-                final Endpoint server = Endpoint.newBuilder().setHostname("127.0.0.1")
+                final Endpoint server = Endpoint.newBuilder().setHostname(ByteString.copyFromUtf8("127.0.0.1"))
                         .setPort(9001 + i).build();
                 final RapidRequest msg = RapidRequest.newBuilder().setProbeMessage(ProbeMessage.getDefaultInstance())
                         .build();


### PR DESCRIPTION
This is a bit of a controversial change from the view point of the API, yet makes a lot of sense from the view point of performance and memory utilization for very large clusters.

The issue here is that the hostname of an `Endpoint` is modelled as a protobuf `string` type. This type carries with it the overhead of encoding to or decoding from UTF-8 every time a message is sent or received (and the field accessed).

From the view point of the algorithms in place, there's no added value in having the endpoint host data be encoded as byte array or utf-8 encoded string. It is just data, what matters is that the ordering of the endpoints can be established. Having a string only matters at the interfaces: when configuring a hostname, when sending a message to one and when printing log statements (most of which at DEBUG/TRACE level).

Yet at the moment, when adding a new endpoint to the membership ring(s), the following code runs:

```java
  public java.lang.String getHostname() {
    java.lang.Object ref = hostname_;
    if (ref instanceof java.lang.String) {
      return (java.lang.String) ref;
    } else {
      com.google.protobuf.ByteString bs =
          (com.google.protobuf.ByteString) ref;
      java.lang.String s = bs.toStringUtf8();
      hostname_ = s;
      return s;
    }
  }

```

For freshly received messages containing Endpoints, this means running `toStringUtf8()`, which when there are many is quite expensive in terms of CPU and memory usage.

This PR does the following:

- use `bytes` rather than `string` to encode the hostname in protobuf
- adjust all interfaces - the Cluster APIs are actually (almost) not affected since they use the `HostAndPort` construct
- use the existing underlying / existing byte array when computing the hashcode of an Endpoint in `Utils.AddressComparator`
- getting rid of the mapping between `Map<String, Metadata>` and `Map<Endpoint, Metadata>` by representing the map as two lists in protobuf (keys and values)

On local tests with 1000 concurrent nodes joining, there's a 10% improvement in memory allocation and a 20% improvement in CPU usage of the stack starting at the `TreeSet.add` method (39% vs 58%).

**Memory allocation before:**

![allocation-profile-before](https://user-images.githubusercontent.com/459669/77916587-9266e100-7299-11ea-9b7a-98dc255a608c.png)

**Memory allocation after:**

![allocation-profile-after](https://user-images.githubusercontent.com/459669/77916598-97c42b80-7299-11ea-8ed8-fc4d9f28b1c2.png)

**CPU before:**

![cpu-profile-before](https://user-images.githubusercontent.com/459669/77916618-9f83d000-7299-11ea-9908-d25b4e3ec516.png)

**CPU after:**

![cpu-profile-after](https://user-images.githubusercontent.com/459669/77916625-a3175700-7299-11ea-9ace-06ae81d5b02c.png)

