### PR TITLE
Fixing compilation error

### DIFF
--- a/rapid/src/main/java/com/vrg/rapid/MembershipService.java
+++ b/rapid/src/main/java/com/vrg/rapid/MembershipService.java
@@ -114,7 +114,7 @@ public final class MembershipService {
 
     MembershipService(final Endpoint myAddr, final MultiNodeCutDetector cutDetection,
                       final MembershipView membershipView, final SharedResources sharedResources,
-                      final ISettings settings, final IMessagingClient messagingClient,
+                      final Settings settings, final IMessagingClient messagingClient,
                       final IEdgeFailureDetectorFactory edgeFailureDetector) {
         this(myAddr, cutDetection, membershipView, sharedResources, settings, messagingClient,
              edgeFailureDetector, Collections.emptyMap(), new EnumMap<>(ClusterEvents.class));


### PR DESCRIPTION
In order for FastPaxos to also have its set of Settings, MemberShipService needs to be passed a common Settings class that implements both FastPaxos.ISettings and MembershipService.ISettings