### PR TITLE
Simple anti-entropy mechanism

### DIFF
--- a/rapid/src/main/java/com/vrg/rapid/MembershipService.java
+++ b/rapid/src/main/java/com/vrg/rapid/MembershipService.java
@@ -114,7 +114,7 @@ public final class MembershipService {
 
     MembershipService(final Endpoint myAddr, final MultiNodeCutDetector cutDetection,
                       final MembershipView membershipView, final SharedResources sharedResources,
-                      final ISettings settings, final IMessagingClient messagingClient,
+                      final Settings settings, final IMessagingClient messagingClient,
                       final IEdgeFailureDetectorFactory edgeFailureDetector) {
         this(myAddr, cutDetection, membershipView, sharedResources, settings, messagingClient,
              edgeFailureDetector, Collections.emptyMap(), new EnumMap<>(ClusterEvents.class));

--- a/rapid/src/main/java/com/vrg/rapid/MembershipView.java
+++ b/rapid/src/main/java/com/vrg/rapid/MembershipView.java
@@ -54,6 +54,7 @@ final class MembershipView {
     @GuardedBy("rwLock") private long currentConfigurationId = -1;
     @GuardedBy("rwLock") private Configuration currentConfiguration;
     @GuardedBy("rwLock") private boolean shouldUpdateConfigurationId = true;
+    @GuardedBy("rwLock") private Set<Long> knownConfigurationIds = new HashSet<>();
 
     MembershipView(final int K) {
         assert K > 0;
@@ -439,6 +440,7 @@ final class MembershipView {
     private void updateCurrentConfigurationId() {
         currentConfiguration = new Configuration(identifiersSeen, rings.get(0));
         currentConfigurationId = currentConfiguration.getConfigurationId();
+        knownConfigurationIds.add(currentConfigurationId);
     }
 
     /**
@@ -460,6 +462,19 @@ final class MembershipView {
         finally {
             rwLock.readLock().unlock();
         }
+    }
+
+    /**
+     * Checks whether the provided configurationId is known
+     */
+    boolean isKnownConfigurationId(final long configurationId) {
+        rwLock.readLock().lock();
+        try {
+            return knownConfigurationIds.contains(configurationId);
+        } finally {
+            rwLock.readLock().unlock();
+        }
+
     }
 
     private static final class NodeIdComparator implements Comparator<NodeId>, Serializable {

--- a/rapid/src/main/java/com/vrg/rapid/MembershipView.java
+++ b/rapid/src/main/java/com/vrg/rapid/MembershipView.java
@@ -54,7 +54,6 @@ final class MembershipView {
     @GuardedBy("rwLock") private long currentConfigurationId = -1;
     @GuardedBy("rwLock") private Configuration currentConfiguration;
     @GuardedBy("rwLock") private boolean shouldUpdateConfigurationId = true;
-    @GuardedBy("rwLock") private Set<Long> knownConfigurationIds = new HashSet<>();
 
     MembershipView(final int K) {
         assert K > 0;
@@ -440,7 +439,6 @@ final class MembershipView {
     private void updateCurrentConfigurationId() {
         currentConfiguration = new Configuration(identifiersSeen, rings.get(0));
         currentConfigurationId = currentConfiguration.getConfigurationId();
-        knownConfigurationIds.add(currentConfigurationId);
     }
 
     /**
@@ -462,19 +460,6 @@ final class MembershipView {
         finally {
             rwLock.readLock().unlock();
         }
-    }
-
-    /**
-     * Checks whether the provided configurationId is known
-     */
-    boolean isKnownConfigurationId(final long configurationId) {
-        rwLock.readLock().lock();
-        try {
-            return knownConfigurationIds.contains(configurationId);
-        } finally {
-            rwLock.readLock().unlock();
-        }
-
     }
 
     private static final class NodeIdComparator implements Comparator<NodeId>, Serializable {

--- a/rapid/src/main/java/com/vrg/rapid/Settings.java
+++ b/rapid/src/main/java/com/vrg/rapid/Settings.java
@@ -28,7 +28,6 @@ public final class Settings implements GrpcClient.ISettings, MembershipService.I
     private int batchingWindowInMs = MembershipService.BATCHING_WINDOW_IN_MS;
     private long consensusFallbackTimeoutBaseDelayInMs = FastPaxos.BASE_DELAY;
     private int membershipViewTimeoutInMs = MembershipService.MEMBERSHIP_VIEW_TIMEOUT_IN_MS;
-    private boolean leaveOnMembershipViewTimeout = MembershipService.LEAVE_ON_MEMBERSHIP_VIEW_TIMEOUT;
 
     /*
      * Settings from GrpcClient.ISettings
@@ -108,15 +107,6 @@ public final class Settings implements GrpcClient.ISettings, MembershipService.I
 
     public void setMembershipViewUpdateTimeoutInMs(final int membershipViewTimeoutInMs) {
         this.membershipViewTimeoutInMs = membershipViewTimeoutInMs;
-    }
-
-    @Override
-    public boolean leaveOnMembershipViewUpdateTimeout() {
-        return leaveOnMembershipViewTimeout;
-    }
-
-    public void setLeaveOnMembershipViewTimeout(final boolean leaveOnMembershipViewTimeout) {
-        this.leaveOnMembershipViewTimeout = leaveOnMembershipViewTimeout;
     }
 
     /*

--- a/rapid/src/main/java/com/vrg/rapid/Settings.java
+++ b/rapid/src/main/java/com/vrg/rapid/Settings.java
@@ -28,6 +28,7 @@ public final class Settings implements GrpcClient.ISettings, MembershipService.I
     private int batchingWindowInMs = MembershipService.BATCHING_WINDOW_IN_MS;
     private long consensusFallbackTimeoutBaseDelayInMs = FastPaxos.BASE_DELAY;
     private int membershipViewTimeoutInMs = MembershipService.MEMBERSHIP_VIEW_TIMEOUT_IN_MS;
+    private boolean leaveOnMembershipViewTimeout = MembershipService.LEAVE_ON_MEMBERSHIP_VIEW_TIMEOUT;
 
     /*
      * Settings from GrpcClient.ISettings
@@ -107,6 +108,15 @@ public final class Settings implements GrpcClient.ISettings, MembershipService.I
 
     public void setMembershipViewUpdateTimeoutInMs(final int membershipViewTimeoutInMs) {
         this.membershipViewTimeoutInMs = membershipViewTimeoutInMs;
+    }
+
+    @Override
+    public boolean leaveOnMembershipViewUpdateTimeout() {
+        return leaveOnMembershipViewTimeout;
+    }
+
+    public void setLeaveOnMembershipViewTimeout(final boolean leaveOnMembershipViewTimeout) {
+        this.leaveOnMembershipViewTimeout = leaveOnMembershipViewTimeout;
     }
 
     /*

--- a/rapid/src/main/java/com/vrg/rapid/Settings.java
+++ b/rapid/src/main/java/com/vrg/rapid/Settings.java
@@ -27,6 +27,7 @@ public final class Settings implements GrpcClient.ISettings, MembershipService.I
     private int failureDetectorIntervalInMs = MembershipService.DEFAULT_FAILURE_DETECTOR_INTERVAL_IN_MS;
     private int batchingWindowInMs = MembershipService.BATCHING_WINDOW_IN_MS;
     private long consensusFallbackTimeoutBaseDelayInMs = FastPaxos.BASE_DELAY;
+    private int membershipViewTimeoutInMs = MembershipService.MEMBERSHIP_VIEW_TIMEOUT_IN_MS;
 
     /*
      * Settings from GrpcClient.ISettings
@@ -96,6 +97,16 @@ public final class Settings implements GrpcClient.ISettings, MembershipService.I
 
     public void setBatchingWindowInMs(final int batchingWindowInMs) {
         this.batchingWindowInMs = batchingWindowInMs;
+    }
+
+
+    @Override
+    public int getMembershipViewUpdateTimeoutInMs() {
+        return this.membershipViewTimeoutInMs;
+    }
+
+    public void setMembershipViewUpdateTimeoutInMs(final int membershipViewTimeoutInMs) {
+        this.membershipViewTimeoutInMs = membershipViewTimeoutInMs;
     }
 
     /*

--- a/rapid/src/main/java/com/vrg/rapid/monitoring/IEdgeFailureDetectorFactory.java
+++ b/rapid/src/main/java/com/vrg/rapid/monitoring/IEdgeFailureDetectorFactory.java
@@ -30,5 +30,5 @@ import io.grpc.ExperimentalApi;
  */
 @ExperimentalApi
 public interface IEdgeFailureDetectorFactory {
-    Runnable createInstance(final Endpoint subject, final Runnable notifier);
+    Runnable createInstance(final Endpoint subject, final long configuraitonId, final Runnable notifier);
 }

--- a/rapid/src/main/java/com/vrg/rapid/monitoring/impl/PingPongFailureDetector.java
+++ b/rapid/src/main/java/com/vrg/rapid/monitoring/impl/PingPongFailureDetector.java
@@ -53,7 +53,7 @@ public class PingPongFailureDetector implements Runnable {
     // A cache for probe messages. Avoids creating an unnecessary copy of a probe message each time.
     private final RapidRequest probeMessage;
 
-    private PingPongFailureDetector(final Endpoint address, final Endpoint subject,
+    private PingPongFailureDetector(final Endpoint address, final Endpoint subject, final long configurationId,
                                     final IMessagingClient rpcClient, final Runnable notifier) {
         this.address = address;
         this.subject = subject;
@@ -62,7 +62,11 @@ public class PingPongFailureDetector implements Runnable {
         this.failureCount = new AtomicInteger(0);
         this.bootstrapResponseCount = new AtomicInteger(0);
         this.probeMessage = RapidRequest.newBuilder().setProbeMessage(
-                ProbeMessage.newBuilder().setSender(address).build()).build();
+                ProbeMessage.newBuilder()
+                        .setSender(address)
+                        .setObserverConfigurationId(configurationId)
+                        .build()
+        ).build();
     }
 
     // Executed at observer
@@ -134,8 +138,8 @@ public class PingPongFailureDetector implements Runnable {
         }
 
         @Override
-        public Runnable createInstance(final Endpoint subject, final Runnable notifier) {
-            return new PingPongFailureDetector(address, subject, messagingClient, notifier);
+        public Runnable createInstance(final Endpoint subject, final long configurationId, final Runnable notifier) {
+            return new PingPongFailureDetector(address, subject, configurationId, messagingClient, notifier);
         }
     }
 }

--- a/rapid/src/main/proto/rapid.proto
+++ b/rapid/src/main/proto/rapid.proto
@@ -31,6 +31,7 @@ message RapidRequest
         Phase2aMessage phase2aMessage = 8;
         Phase2bMessage phase2bMessage = 9;
         LeaveMessage leaveMessage = 10;
+        SynchronizationMessage synchronizationMessage = 11;
    }
 }
 
@@ -41,6 +42,7 @@ message RapidResponse
         Response response = 2;
         ConsensusResponse consensusResponse = 3;
         ProbeResponse probeResponse = 4;
+        SynchronizationResponse synchronizationResponse = 5;
    }
 }
 
@@ -204,3 +206,27 @@ enum NodeStatus {
     OK = 0;             // this is the default value
     BOOTSTRAPPING = 1;
 };
+
+// ******* Used by the anti-entropy mechanism *******
+
+message SynchronizationMessage
+{
+    Endpoint sender = 1;
+    int64 configurationId = 2;
+}
+
+message SynchronizationResponse
+{
+    Endpoint sender = 1;
+    repeated ViewChange changes = 2;
+}
+
+message ViewChange
+{
+    int64 configurationId = 1;
+    repeated Endpoint endpoints = 2;
+    repeated Endpoint nodeIdKeys = 3;
+    repeated NodeId nodeIdValues = 4;
+    repeated Endpoint metadataKeys = 5;
+    repeated Metadata metadataValues = 6;
+}

--- a/rapid/src/main/proto/rapid.proto
+++ b/rapid/src/main/proto/rapid.proto
@@ -192,7 +192,7 @@ message LeaveMessage
 message ProbeMessage
 {
     Endpoint sender = 1;
-    repeated bytes payload = 3;
+    int64 observerConfigurationId = 2;
 }
 
 message ProbeResponse

--- a/rapid/src/test/java/com/vrg/rapid/ClusterTest.java
+++ b/rapid/src/test/java/com/vrg/rapid/ClusterTest.java
@@ -360,10 +360,10 @@ public class ClusterTest {
     }
 
     /**
-     * Check the anti-entropy mechanism that nudges members that have missed a consensus round to proactively leave
+     * Check the anti-entropy mechanism that catches up members that have missed a consensus round
      */
-    @Test(timeout = 40000)
-    public void missConsensusMessages() throws IOException, InterruptedException {
+    @Test(timeout = 50000)
+    public void missConsensusMessagesAndSync() throws IOException, InterruptedException {
         useFastFailureDetectionTimeouts();
         final int membershipViewUpdateTimeoutInMs = 5000;
         settings.setMembershipViewUpdateTimeoutInMs(membershipViewUpdateTimeoutInMs);
@@ -381,8 +381,14 @@ public class ClusterTest {
 
         extendCluster(numNodesPhase2, seedEndpoint);
 
+
         final Map<Endpoint, Cluster> instancesToCheck = new HashMap<>(instances);
         instancesToCheck.remove(staleNode);
+
+        final AtomicBoolean hasSynchronized = new AtomicBoolean(false);
+        instances.get(staleNode).registerSubscription(ClusterEvents.VIEW_CHANGE, (configurationId, statusChanges) -> {
+            hasSynchronized.set(true);
+        });
 
         // the other nodes will see all nodes
         waitAndVerifyAgreement(numNodesPhase1 + numNodesPhase2 + 1, 10, 2000, instancesToCheck);
@@ -391,6 +397,41 @@ public class ClusterTest {
         // the stale node will be out of date
         assertEquals(numNodesPhase1 + 1, instances.get(staleNode).getMemberlist().size());
 
+        Thread.sleep(membershipViewUpdateTimeoutInMs);
+        assertTrue(hasSynchronized.get());
+
+        // all nodes should be in agreement
+        waitAndVerifyAgreement(numNodesPhase1 + numNodesPhase2 + 1, 5, 1000);
+    }
+
+
+    /**
+     * Check the anti-entropy mechanism that nudges members that have missed a consensus round to proactively leave
+     */
+    @Test(timeout = 40000)
+    public void missConsensusMessagesAndLeave() throws IOException, InterruptedException {
+        settings.setGrpcProbeTimeoutMs(300);
+        settings.setFailureDetectorIntervalInMs(50);
+        final int membershipViewUpdateTimeoutInMs = 5000;
+        settings.setMembershipViewUpdateTimeoutInMs(membershipViewUpdateTimeoutInMs);
+        settings.setLeaveOnMembershipViewTimeout(true);
+        final int numNodesPhase1 = 40;
+        final int numNodesPhase2 = 5;
+        final Endpoint seedEndpoint = Utils.hostFromParts("127.0.0.1", basePort);
+        createCluster(numNodesPhase1, seedEndpoint);
+        verifyCluster(numNodesPhase1);
+
+        // node that will miss consensus messages joins. needs to join now because of the way drop helpers work
+        final Endpoint staleNode = Utils.hostFromParts("127.0.0.1", portCounter.incrementAndGet());
+        dropFirstNAtServer(staleNode, 1000, RapidRequest.ContentCase.FASTROUNDPHASE2BMESSAGE);
+        extendCluster(staleNode, seedEndpoint);
+        waitAndVerifyAgreement(numNodesPhase1 + 1, 10, 2000);
+
+        extendCluster(numNodesPhase2, seedEndpoint);
+
+        final Map<Endpoint, Cluster> instancesToCheck = new HashMap<>(instances);
+        instancesToCheck.remove(staleNode);
+
         final AtomicBoolean hasLeft = new AtomicBoolean(false);
         instances.get(staleNode).registerSubscription(ClusterEvents.KICKED, (configurationId, statusChanges) -> {
             hasLeft.set(true);
@@ -398,12 +439,18 @@ public class ClusterTest {
             instances.remove(staleNode);
         });
 
+        // the other nodes will see all nodes
+        waitAndVerifyAgreement(numNodesPhase1 + numNodesPhase2 + 1, 10, 2000, instancesToCheck);
+        assertTrue(instances.get(seedEndpoint).getMemberlist().contains(staleNode));
+
+        // the stale node will be out of date
+        assertEquals(numNodesPhase1 + 1, instances.get(staleNode).getMemberlist().size());
+
         Thread.sleep(membershipViewUpdateTimeoutInMs);
         assertTrue(hasLeft.get());
 
-
         // the stale node having left proactively, it should no longer be part of the membership on the other nodes
-        waitAndVerifyAgreement(numNodesPhase1 + numNodesPhase2, 20, 2000);
+        waitAndVerifyAgreement(numNodesPhase1 + numNodesPhase2, 20, 1000);
     }
 
     /**

--- a/rapid/src/test/java/com/vrg/rapid/StaticFailureDetector.java
+++ b/rapid/src/test/java/com/vrg/rapid/StaticFailureDetector.java
@@ -52,7 +52,8 @@ class StaticFailureDetector implements Runnable {
         }
 
         @Override
-        public Runnable createInstance(final Endpoint observer, final Runnable notification) {
+        public Runnable createInstance(final Endpoint observer, final long configurationId,
+                                       final Runnable notification) {
             return new StaticFailureDetector(observer, notification, blackList);
         }
 


### PR DESCRIPTION
It can happen that a node misses a part of the consensus messages whilst still being able to send out its own vote (unidirectional network partition, message overload, ...). In this case, the rest of the group will see this node as being part of the group and the monitoring mechanism will still be working as expected, but the stale node will run an old configuration.
    
In order to enforce consistency in this case, the following new anti-entropy mechanism is introduced:
    
- each node maintains a set of configurations it has been part of
- probe messages now contain the configuration ID of the observer
- when a node receives a probe message with a configuration ID it does not know, it will start a background task to check again after a configured timeout (1 minute by default)
- if the configuration ID is still unknown after the timeout has reached, the node leaves proactively (using the LEAVE protocol)