### PR TITLE
Consistent-hash based broadcaster

### DIFF
--- a/rapid/src/main/java/com/vrg/rapid/Cluster.java
+++ b/rapid/src/main/java/com/vrg/rapid/Cluster.java
@@ -331,6 +331,10 @@ public final class Cluster {
                         case HOSTNAME_ALREADY_IN_RING:
                             LOG.error("Membership rejected by {}. Retrying.", Utils.loggable(result.getSender()));
                             break;
+                        case VIEW_CHANGE_IN_PROGRESS:
+                            LOG.info("Seed node {} is executing a view change. Retrying.",
+                                    Utils.loggable(result.getSender()));
+                            break;
                         default:
                             this.seedAddress = null;
                             throw new JoinException("Unrecognized status code");

--- a/rapid/src/main/java/com/vrg/rapid/ConsistentHash.java
+++ b/rapid/src/main/java/com/vrg/rapid/ConsistentHash.java
@@ -1,0 +1,64 @@
+package com.vrg.rapid;
+
+import com.vrg.rapid.pb.Endpoint;
+import net.openhft.hashing.LongHashFunction;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+/**
+ * Simple consistent Hash implementation, adapted for Endpoints
+ *
+ * https://tom-e-white.com/2007/11/consistent-hashing.html
+ */
+public class ConsistentHash<T> {
+
+    private final LongHashFunction hashFunction = LongHashFunction.xx();
+    private final int numberOfReplicas;
+    private final SortedMap<Long, Endpoint> circle = new TreeMap<>();
+
+    public ConsistentHash(final int numberOfReplicas, final Collection<Endpoint> nodes) {
+        this.numberOfReplicas = numberOfReplicas;
+
+        for (final Endpoint node : nodes) {
+            add(node);
+        }
+    }
+
+    public void add(final Endpoint node) {
+        for (int i = 0; i < numberOfReplicas; i++) {
+            circle.put(hash(node, i), node);
+        }
+    }
+
+    public void remove(final Endpoint node) {
+        for (int i = 0; i < numberOfReplicas; i++) {
+            circle.remove(hash(node, i));
+        }
+    }
+
+    public boolean isEmpty() {
+        return circle.isEmpty();
+    }
+
+    @Nullable
+    public Endpoint get(final Endpoint key) {
+        if (circle.isEmpty()) {
+            return null;
+        }
+        long hash = hash(key, 0);
+        if (!circle.containsKey(hash)) {
+            final SortedMap<Long, Endpoint> tailMap = circle.tailMap(hash);
+            hash = tailMap.isEmpty() ? circle.firstKey() : tailMap.firstKey();
+        }
+        return circle.get(hash);
+    }
+
+    private long hash(final Endpoint node, final int index) {
+        return hashFunction.hashBytes(node.getHostname().asReadOnlyByteBuffer()) * 31
+                + hashFunction.hashInt(node.getPort()) + hashFunction.hashInt(index);
+    }
+
+}

--- a/rapid/src/main/java/com/vrg/rapid/ConsistentHashBroadcaster.java
+++ b/rapid/src/main/java/com/vrg/rapid/ConsistentHashBroadcaster.java
@@ -1,0 +1,364 @@
+package com.vrg.rapid;
+
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.ExperimentalApi;
+import com.vrg.rapid.messaging.IBroadcaster;
+import com.vrg.rapid.messaging.IMessagingClient;
+import com.vrg.rapid.pb.BroadcastingMessage;
+import com.vrg.rapid.pb.Endpoint;
+import com.vrg.rapid.pb.FastRoundPhase2bMessage;
+import com.vrg.rapid.pb.Metadata;
+import com.vrg.rapid.pb.Proposal;
+import com.vrg.rapid.pb.RapidRequest;
+import com.vrg.rapid.pb.RapidResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * Broadcaster based on a ring of broadcasting nodes organized via consistent hashing.
+ *
+ * Nodes in the cluster are segregated in two groups:
+ * - broadcasting nodes (B) that will relay messages to be broadcasted to all
+ * - "broadastee" nodes (n) that send the messages to be broadcasted to "their" broadcaster
+ *
+ * The goal is to minimize the amount of connections to other nodes that need to be maintained by a single node.
+ *
+ *
+ *                                          n n n n n
+ *                                     n        |        n
+ *                                     n        B        n
+ *                                     n ---- B   B ---- n
+ *                                     n        B        n
+ *                                     n        |        n
+ *                                          n n n n n
+ *
+ *
+ * Broadcasting works as follows:
+ * 1. A node that wants to broadcast a message sends it to it broadcaster
+ * 2. The broadcaster forwards the message to all other broadcasters and to all other of its broadcastees
+ * 3. Each broadcaster receiving a message forwards it to all of its broadcastees
+ *
+ * Additionally, fast paxos vote messages are batched together at two levels:
+ * - when first received by the broadcasting node of a group of "broadcastees"
+ * - when the broadcasted messages are subsequently received by the other broadcasters
+ *
+ * Broadcasters are discovered automatically via node meta-data. A node acts as broadcaster if configured to do so
+ * via the Settings.
+ *
+ * /!\ NOTE: This broadcasting strategy does **not preserve the order of messages**.
+ *
+ */
+@ExperimentalApi
+public class ConsistentHashBroadcaster implements IBroadcaster {
+
+    static final int CONSISTENT_HASH_REPLICAS = 200;
+
+    private static final Logger LOG = LoggerFactory.getLogger(ConsistentHashBroadcaster.class);
+
+    private final boolean isBroadcaster;
+    private final IMessagingClient messagingClient;
+    private final MembershipView membershipView;
+    private final Endpoint myAddress;
+
+    private final ReadWriteLock rwLock = new ReentrantReadWriteLock();
+    @GuardedBy("rwLock") private Set<Endpoint> allRecipients = new HashSet<>();
+    @GuardedBy("rwLock") private Set<Endpoint> myRecipients = new HashSet<>();
+
+    private ConsistentHash<Endpoint> broadcasterRing =
+            new ConsistentHash<>(CONSISTENT_HASH_REPLICAS, Collections.emptyList());
+    private Set<Endpoint> allBroadcasters = new HashSet<>();
+
+    private final MessageBatcher<FastRoundPhase2bMessage> broadcasterMessageBatcher;
+    private final MessageBatcher<FastRoundPhase2bMessage> recipientMessageBatcher;
+
+    public ConsistentHashBroadcaster(final IMessagingClient messagingClient,
+                                     final MembershipView membershipView,
+                                     final Endpoint myAddress,
+                                     final Optional<Metadata> myMetadata,
+                                     final SharedResources sharedResources,
+                                     final int consensusBatchingWindowInMs) {
+        this.messagingClient = messagingClient;
+        this.membershipView = membershipView;
+        this.myAddress = myAddress;
+
+        this.isBroadcaster = myMetadata.isPresent() && isBroadcasterNode(myMetadata.get());
+
+        this.broadcasterMessageBatcher = new BroadcasterMessageBatcher(sharedResources, consensusBatchingWindowInMs);
+        this.recipientMessageBatcher = new RecipientMessageBatcher(sharedResources, consensusBatchingWindowInMs);
+
+        // Schedule fast paxos job
+        if (isBroadcaster) {
+            broadcasterMessageBatcher.start();
+            recipientMessageBatcher.start();
+        }
+    }
+
+    @Override
+    @CanIgnoreReturnValue
+    public List<ListenableFuture<RapidResponse>> broadcast(final RapidRequest rapidRequest,
+                                                           final long configurationId) {
+        final List<ListenableFuture<RapidResponse>> responses = new ArrayList<>();
+        if (!broadcasterRing.isEmpty()) {
+            final BroadcastingMessage.Builder broadcastingMessageBuilder = BroadcastingMessage.newBuilder()
+                            .setMessage(rapidRequest)
+                            .setConfigurationId(configurationId);
+
+            if (isBroadcaster) {
+                // directly send the message to other broadcasters for retransmission
+                sendToBroadcastersAndRecipients(broadcastingMessageBuilder.setShouldDeliver(true).build());
+            } else {
+                if (rapidRequest.getContentCase().equals(RapidRequest.ContentCase.BATCHEDALERTMESSAGE)) {
+                    // deliver to ourselves first
+                    // at scale, this matters, as we may otherwise receive consensus messages (while still broadcasting)
+                    // before having processed the batched alert message
+                    final ListenableFuture<RapidResponse> myResponse =
+                            messagingClient.sendMessage(myAddress, rapidRequest);
+                    responses.add(myResponse);
+                    Futures.addCallback(myResponse,
+                            new ErrorReportingCallback(rapidRequest.getContentCase(), myAddress));
+                }
+
+                // send it to our broadcaster who will take care of retransmission
+                final RapidRequest request = Utils.toRapidRequest(
+                        broadcastingMessageBuilder.setShouldDeliver(false).build()
+                );
+                final Endpoint broadcaster = broadcasterRing.get(myAddress);
+                final ListenableFuture<RapidResponse> response = messagingClient.sendMessage(broadcaster, request);
+                Futures.addCallback(response, new ErrorReportingCallback(request.getContentCase(), broadcaster));
+                responses.add(response);
+            }
+        } else {
+            // fall back to direct broadcasting
+            // this happens e.g. when the seed node joins
+            allRecipients.forEach(node -> {
+                responses.add(messagingClient.sendMessageBestEffort(node, rapidRequest));
+            });
+
+        }
+        return responses;
+    }
+
+    @Override
+    public void onNodeAdded(final Endpoint node, final Optional<Metadata> metadata) {
+        rwLock.writeLock().lock();
+        try {
+            allRecipients.add(node);
+            final boolean addedNodeIsBroadcaster = metadata.isPresent() && isBroadcasterNode(metadata.get());
+            if (!allBroadcasters.contains(node) && addedNodeIsBroadcaster) {
+                broadcasterRing.add(node);
+                allBroadcasters.add(node);
+            }
+            if (isBroadcaster) {
+                final Endpoint responsibleBroadcaster = broadcasterRing.get(node);
+                if (myAddress.equals(responsibleBroadcaster)) {
+                    myRecipients.add(node);
+                }
+            }
+        } finally {
+            rwLock.writeLock().unlock();
+        }
+    }
+
+    @Override
+    public void onNodeRemoved(final Endpoint node) {
+        rwLock.writeLock().lock();
+        try {
+            allRecipients.remove(node);
+            broadcasterRing.remove(node);
+            allBroadcasters.remove(node);
+            myRecipients.remove(node);
+        } finally {
+            rwLock.writeLock().unlock();
+        }
+    }
+
+    public ListenableFuture<RapidResponse> handleBroadcastingMessage(final BroadcastingMessage msg) {
+        final SettableFuture<RapidResponse> future = SettableFuture.create();
+        if (msg.getShouldDeliver()) {
+            // this message already went through the ring, deliver to our recipients
+            sendToOwnRecipients(msg.getMessage(), true);
+        } else {
+            // pass it on to all other broadcasters, and deliver to our recipients
+            sendToBroadcastersAndRecipients(msg.toBuilder().setShouldDeliver(true).build());
+        }
+        future.set(null);
+        return future;
+    }
+
+    private boolean isBroadcasterNode(final Metadata nodeMetadata) {
+        return nodeMetadata.getMetadataCount() > 0
+                && nodeMetadata.getMetadataMap().containsKey(Cluster.BROADCASTER_METADATA_KEY);
+    }
+
+    private void sendToOwnRecipients(final RapidRequest msg, final boolean shouldBatch) {
+        if (shouldBatch && msg.getContentCase() == RapidRequest.ContentCase.FASTROUNDPHASE2BMESSAGE) {
+            recipientMessageBatcher.enqueueMessage(msg.getFastRoundPhase2BMessage());
+        } else {
+            try {
+                rwLock.readLock().lock();
+                // send to myself first
+                Futures.addCallback(messagingClient.sendMessage(myAddress, msg),
+                        new ErrorReportingCallback(msg.getContentCase(), myAddress));
+
+                // then to the rest
+
+                // except for when it's a batched alert message, we also do not send it to the sender
+                final Set<Endpoint> recipientsToSkip = new HashSet<>();
+                recipientsToSkip.add(myAddress);
+                if (msg.getContentCase().equals(RapidRequest.ContentCase.BATCHEDALERTMESSAGE)) {
+                    recipientsToSkip.add(msg.getBatchedAlertMessage().getSender());
+                }
+
+                myRecipients.forEach(node -> {
+                    if (!recipientsToSkip.contains(node)) {
+                        Futures.addCallback(messagingClient.sendMessage(node, msg),
+                                new ErrorReportingCallback(msg.getContentCase(), myAddress));
+                    }
+                });
+            } finally {
+                rwLock.readLock().unlock();
+            }
+        }
+    }
+
+    @CanIgnoreReturnValue
+    private ListenableFuture<?> sendToBroadcastersAndRecipients(final BroadcastingMessage broadcastingMessage) {
+        // first send to the broadcasters and only then to the recipients
+        final ListenableFuture<List<RapidResponse>> broadcasterResponses =
+                Futures.successfulAsList(sendToBroadcasters(broadcastingMessage, true));
+
+        return Futures.transform(broadcasterResponses, rapidResponses -> {
+            if (!broadcastingMessage.getMessage().getContentCase()
+			.equals(RapidRequest.ContentCase.FASTROUNDPHASE2BMESSAGE)
+                    && rapidResponses.size() != allBroadcasters.size() - 1) {
+                LOG.warn("Could not deliver request of type {} to all broadcasters!",
+                        broadcastingMessage.getMessage().getContentCase().name());
+            }
+            sendToOwnRecipients(broadcastingMessage.getMessage(), true);
+            return rapidResponses;
+        });
+    }
+
+    private List<ListenableFuture<RapidResponse>> sendToBroadcasters(final BroadcastingMessage message,
+                                                                     final boolean shouldBatch) {
+        final List<ListenableFuture<RapidResponse>> responses = new ArrayList<>();
+        if (shouldBatch &&
+                message.getMessage().getContentCase().equals(RapidRequest.ContentCase.FASTROUNDPHASE2BMESSAGE)) {
+            broadcasterMessageBatcher.enqueueMessage(message.getMessage().getFastRoundPhase2BMessage());
+        } else {
+            rwLock.readLock().lock();
+            try {
+                allBroadcasters.stream().filter(node -> !node.equals(myAddress)).forEach(node -> {
+                    final ListenableFuture<RapidResponse> response =
+                            messagingClient.sendMessage(node, Utils.toRapidRequest(message));
+                    Futures.addCallback(response,
+                            new ErrorReportingCallback(message.getMessage().getContentCase(), node));
+                    responses.add(response);
+                });
+            } finally {
+                rwLock.readLock().unlock();
+            }
+        }
+        return responses;
+    }
+
+    private FastRoundPhase2bMessage compressConsensusMessages(final List<FastRoundPhase2bMessage> messages) {
+        // compress all the messages into one
+        final Map<List<Endpoint>, BitSet> allProposals = new HashMap<>();
+        final Map<List<Endpoint>, Long> allProposalConfigurationIds = new HashMap<>();
+        for (final FastRoundPhase2bMessage consensusMessage : messages) {
+            for (final Proposal proposal : consensusMessage.getProposalsList()) {
+                final BitSet allVotes = allProposals.computeIfAbsent(proposal.getEndpointsList(),
+                        endpoints -> BitSet.valueOf(proposal.getVotes().toByteArray()));
+                allVotes.or(BitSet.valueOf(proposal.getVotes().toByteArray()));
+                allProposals.put(proposal.getEndpointsList(), allVotes);
+                allProposalConfigurationIds.put(proposal.getEndpointsList(), proposal.getConfigurationId());
+            }
+        }
+        final List<Proposal> allProposalMessages = new ArrayList<>();
+        allProposals.entrySet().forEach(entry -> {
+            final Proposal proposal = Proposal.newBuilder()
+                    // configuration IDs should be stable for proposals affecting the same nodes
+                    .setConfigurationId(allProposalConfigurationIds.get(entry.getKey()))
+                    .addAllEndpoints(entry.getKey())
+                    .setVotes(ByteString.copyFrom(entry.getValue().toByteArray()))
+                    .build();
+            allProposalMessages.add(proposal);
+        });
+        final FastRoundPhase2bMessage batched = FastRoundPhase2bMessage.newBuilder()
+                .addAllProposals(allProposalMessages)
+                .build();
+        return batched;
+    }
+
+    private class BroadcasterMessageBatcher extends MessageBatcher<FastRoundPhase2bMessage> {
+        public BroadcasterMessageBatcher(final SharedResources sharedResources, final int batchingWindowInMs) {
+            super(sharedResources, batchingWindowInMs);
+        }
+
+        @Override
+        public void sendMessages(final List<FastRoundPhase2bMessage> messages) {
+            final FastRoundPhase2bMessage batched = compressConsensusMessages(messages);
+            final BroadcastingMessage message = BroadcastingMessage.newBuilder()
+                    .setMessage(Utils.toRapidRequest(batched))
+                    .setShouldDeliver(true)
+                    .setConfigurationId(membershipView.getCurrentConfigurationId())
+                    .build();
+            sendToBroadcasters(message, false);
+        }
+    }
+
+    private class RecipientMessageBatcher extends MessageBatcher<FastRoundPhase2bMessage> {
+        public RecipientMessageBatcher(final SharedResources sharedResources, final int batchingWindowInMs) {
+            super(sharedResources, batchingWindowInMs);
+        }
+
+        @Override
+        public void sendMessages(final List<FastRoundPhase2bMessage> messages) {
+            final FastRoundPhase2bMessage batched = compressConsensusMessages(messages);
+            sendToOwnRecipients(Utils.toRapidRequest(batched), false);
+        }
+    }
+
+    private static class ErrorReportingCallback implements FutureCallback<RapidResponse> {
+        private final RapidRequest.ContentCase requestType;
+        private final Endpoint recipient;
+
+        public ErrorReportingCallback(final RapidRequest.ContentCase requestType, final Endpoint recipient) {
+            this.requestType = requestType;
+            this.recipient = recipient;
+        }
+
+        private static final Logger LOG = LoggerFactory.getLogger(ConsistentHashBroadcaster.class);
+
+        @Override
+        public void onSuccess(@Nullable final RapidResponse rapidResponse) {
+        }
+
+        @Override
+        public void onFailure(final Throwable throwable) {
+            LOG.warn("Failed to broadcast request of type {} to {}:{}",
+                    requestType.name(), recipient.getHostname().toStringUtf8(), recipient.getPort());
+        }
+    }
+
+}

--- a/rapid/src/main/java/com/vrg/rapid/MembershipService.java
+++ b/rapid/src/main/java/com/vrg/rapid/MembershipService.java
@@ -241,8 +241,9 @@ public final class MembershipService {
                             .build();
                     enqueueAlertMessage(msg);
                 }
-            } else {
-                // no.
+            } else if (statusCode == JoinStatusCode.HOSTNAME_ALREADY_IN_RING) {
+                // Do not let the node join. It will have to wait until failure detection kicks in and
+                // a new membership view is agreed upon in order to be able to join again.
                 final JoinResponse response = JoinResponse.newBuilder()
                         .setSender(myAddr)
                         .setStatusCode(statusCode)

--- a/rapid/src/main/java/com/vrg/rapid/MembershipService.java
+++ b/rapid/src/main/java/com/vrg/rapid/MembershipService.java
@@ -13,6 +13,7 @@
 
 package com.vrg.rapid;
 
+import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
@@ -33,9 +34,13 @@ import com.vrg.rapid.pb.ProbeResponse;
 import com.vrg.rapid.pb.RapidRequest;
 import com.vrg.rapid.pb.RapidResponse;
 import com.vrg.rapid.pb.LeaveMessage;
+import com.vrg.rapid.pb.SynchronizationMessage;
+import com.vrg.rapid.pb.SynchronizationResponse;
+import com.vrg.rapid.pb.ViewChange;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.NotThreadSafe;
 import java.util.ArrayList;
@@ -75,6 +80,8 @@ public final class MembershipService {
     static final int BATCHING_WINDOW_IN_MS = 100;
     private static final int DEFAULT_FAILURE_DETECTOR_INITIAL_DELAY_IN_MS = 0;
     static final int DEFAULT_FAILURE_DETECTOR_INTERVAL_IN_MS = 1000;
+    static final int MEMBERSHIP_VIEW_TIMEOUT_IN_MS = 60000;
+    static final boolean LEAVE_ON_MEMBERSHIP_VIEW_TIMEOUT = false;
     private static final int LEAVE_MESSAGE_TIMEOUT = 1500;
     private final MembershipView membershipView;
     private final MultiNodeCutDetector cutDetection;
@@ -86,6 +93,7 @@ public final class MembershipService {
     private final Map<Endpoint, Metadata> joinerMetadata = new HashMap<>();
     private final IMessagingClient messagingClient;
     private final MetadataManager metadataManager;
+    private final List<ViewChange> membershipHistory = Collections.synchronizedList(new ArrayList<>());
 
     // Event subscriptions
     private final Map<ClusterEvents, List<BiConsumer<Long, List<NodeStatusChange>>>> subscriptions;
@@ -110,6 +118,9 @@ public final class MembershipService {
     // Fields used by consensus protocol
     private AtomicBoolean announcedProposal = new AtomicBoolean(false);
     private final Object membershipUpdateLock = new Object();
+
+    private boolean isLeaving = false;
+
     private final Settings settings;
 
 
@@ -184,6 +195,8 @@ public final class MembershipService {
                 return handleConsensusMessages(msg);
             case LEAVEMESSAGE:
                 return handleLeaveMessage(msg);
+            case SYNCHRONIZATIONMESSAGE:
+                return handleMessage(msg.getSynchronizationMessage());
             case CONTENT_NOT_SET:
             default:
                 throw new IllegalArgumentException("Unidentified RapidRequest type " + msg.getContentCase());
@@ -333,6 +346,35 @@ public final class MembershipService {
         return future;
     }
 
+    /**
+     * Compiles a list of view changes that occured since the requesting node last saw a change
+     */
+    private ListenableFuture<RapidResponse> handleMessage(final SynchronizationMessage request) {
+        final SettableFuture<RapidResponse> future = SettableFuture.create();
+
+        // retrieve all the configuration changes after the one of the request
+        final List<ViewChange> changeList = new ArrayList<>();
+
+        boolean configurationIdReached = false;
+        for (final ViewChange viewChange : membershipHistory) {
+            if (configurationIdReached) {
+                changeList.add(viewChange);
+            }
+            if (viewChange.getConfigurationId() == request.getConfigurationId()) {
+                configurationIdReached = true;
+            }
+        }
+
+        final RapidResponse response = RapidResponse.newBuilder().setSynchronizationResponse(
+                SynchronizationResponse.newBuilder()
+                        .setSender(myAddr)
+                        .addAllChanges(changeList)
+                        .build())
+                .build();
+
+        future.set(response);
+        return future;
+    }
 
     /**
      * Receives proposal for the one-step consensus (essentially phase 2 of Fast Paxos).
@@ -366,6 +408,9 @@ public final class MembershipService {
         // The first step is to disable our failure detectors in anticipation of new ones to be created.
         cancelFailureDetectorJobs();
 
+        final Map<Endpoint, NodeId> affectedNodeIds = new HashMap();
+        final Map<Endpoint, Metadata> affectedMetadata = new HashMap<>();
+
         final List<NodeStatusChange> statusChanges = new ArrayList<>(proposal.size());
         synchronized (membershipUpdateLock) {
             for (final Endpoint node : proposal) {
@@ -381,9 +426,11 @@ public final class MembershipService {
                 else {
                     assert joinerUuid.containsKey(node);
                     final NodeId nodeId = joinerUuid.remove(node);
+                    affectedNodeIds.put(node, nodeId);
                     membershipView.ringAdd(node, nodeId);
                     final Metadata metadata = joinerMetadata.remove(node);
                     if (metadata.getMetadataCount() > 0) {
+                        affectedMetadata.put(node, metadata);
                         metadataManager.addMetadata(Collections.singletonMap(node, metadata));
                     }
                     statusChanges.add(new NodeStatusChange(node, EdgeStatus.UP, metadata));
@@ -392,8 +439,19 @@ public final class MembershipService {
         }
 
         final long currentConfigurationId = membershipView.getCurrentConfigurationId();
+
         // Publish an event to the listeners.
         subscriptions.get(ClusterEvents.VIEW_CHANGE).forEach(cb -> cb.accept(currentConfigurationId, statusChanges));
+
+        // Update the membership history
+        membershipHistory.add(ViewChange.newBuilder()
+                .setConfigurationId(currentConfigurationId)
+                .addAllEndpoints(proposal)
+                .addAllNodeIdKeys(affectedNodeIds.keySet())
+                .addAllNodeIdValues(affectedNodeIds.values())
+                .addAllMetadataKeys(affectedMetadata.keySet())
+                .addAllMetadataValues(affectedMetadata.values())
+                .build());
 
         // Clear data structures for the next round.
         cutDetection.clear();
@@ -421,9 +479,46 @@ public final class MembershipService {
     /**
      * Invoked by observers of a node for failure detection.
      */
+    @SuppressWarnings("FutureReturnValueIgnored")
     private ListenableFuture<RapidResponse> handleMessage(final ProbeMessage probeMessage) {
         LOG.trace("handleProbeMessage from {}", Utils.loggable(probeMessage.getSender()));
+        final long observerConfigurationId = probeMessage.getObserverConfigurationId();
+
+        if (!membershipHistory.stream().anyMatch(change -> change.getConfigurationId() == observerConfigurationId)) {
+            backgroundTasksExecutor.schedule(() -> {
+                if (!membershipHistory
+                        .stream().anyMatch(change -> change.getConfigurationId() == observerConfigurationId)) {
+
+                    // we still have not synchronized our worldview after the configured timeout
+                    if (settings.leaveOnMembershipViewUpdateTimeout()) {
+                        // proactively leave the cluster
+                        subscriptions.get(ClusterEvents.KICKED).forEach(cb ->
+                                cb.accept(membershipView.getCurrentConfigurationId(), Collections.emptyList())
+                        );
+                        leave();
+                        shutdown();
+                    } else {
+                        synchronizeView(probeMessage.getSender());
+                    }
+                }
+            }, settings.getMembershipViewUpdateTimeoutInMs(), TimeUnit.MILLISECONDS);
+        }
         return Futures.immediateFuture(Utils.toRapidResponse(ProbeResponse.getDefaultInstance()));
+    }
+
+    private void synchronizeView(final Endpoint observer) {
+        // attempt to retrieve the current member list from the observer
+        final RapidRequest syncRequest = RapidRequest.newBuilder()
+                .setSynchronizationMessage(SynchronizationMessage
+                        .newBuilder()
+                        .setSender(myAddr)
+                        .setConfigurationId(membershipView.getCurrentConfigurationId())
+                        .build())
+                .build();
+        Futures.addCallback(
+                messagingClient.sendMessageBestEffort(observer, syncRequest),
+                new SynchronizationCallback());
+
     }
 
 
@@ -518,24 +613,29 @@ public final class MembershipService {
      * This operation is blocking, as we need to wait to send the alert messages before shutting down the rest
      */
     void leave() {
-        final LeaveMessage leaveMessage = LeaveMessage.newBuilder().setSender(myAddr).build();
-        final RapidRequest leave = RapidRequest.newBuilder().setLeaveMessage(leaveMessage).build();
+        if (!isLeaving) {
+            final LeaveMessage leaveMessage = LeaveMessage.newBuilder().setSender(myAddr).build();
+            final RapidRequest leave = RapidRequest.newBuilder().setLeaveMessage(leaveMessage).build();
 
-        try {
-            final List<Endpoint> observers = membershipView.getObserversOf(myAddr);
-            final ListenableFuture<List<RapidResponse>> leaveResponses = Futures.successfulAsList(observers.stream()
-                    .map(endpoint -> messagingClient.sendMessageBestEffort(endpoint, leave))
-                    .collect(Collectors.toList()));
+            cancelFailureDetectorJobs();
+
             try {
-                leaveResponses.get(LEAVE_MESSAGE_TIMEOUT, TimeUnit.MILLISECONDS);
-            } catch (final InterruptedException | ExecutionException e) {
-                LOG.trace("Exception while leaving", e);
-            } catch (final TimeoutException e) {
-                LOG.trace("Timeout while leaving", e);
+                final List<Endpoint> observers = membershipView.getObserversOf(myAddr);
+                final ListenableFuture<List<RapidResponse>> leaveResponses = Futures.successfulAsList(observers.stream()
+                        .map(endpoint -> messagingClient.sendMessageBestEffort(endpoint, leave))
+                        .collect(Collectors.toList()));
+                isLeaving = true;
+                try {
+                    leaveResponses.get(LEAVE_MESSAGE_TIMEOUT, TimeUnit.MILLISECONDS);
+                } catch (final InterruptedException | ExecutionException e) {
+                    LOG.trace("Exception while leaving", e);
+                } catch (final TimeoutException e) {
+                    LOG.trace("Timeout while leaving", e);
+                }
+            } catch (final MembershipView.NodeNotInRingException e) {
+                // we already were removed, so that's fine
+                LOG.trace("Node was already removed prior to leaving", e);
             }
-        } catch (final MembershipView.NodeNotInRingException e) {
-            // we already were removed, so that's fine
-            LOG.trace("Node was already removed prior to leaving", e);
         }
     }
 
@@ -673,6 +773,7 @@ public final class MembershipService {
         final List<ScheduledFuture<?>> jobs = membershipView.getSubjectsOf(myAddr)
                 .stream().map(subject -> backgroundTasksExecutor
                          .scheduleAtFixedRate(fdFactory.createInstance(subject,
+                                membershipView.getCurrentConfigurationId(),
                                 createNotifierForSubject(subject)), // Runnable
                                 DEFAULT_FAILURE_DETECTOR_INITIAL_DELAY_IN_MS,
                                 settings.getFailureDetectorIntervalInMs(),
@@ -718,9 +819,34 @@ public final class MembershipService {
         }
     }
 
+    class SynchronizationCallback implements FutureCallback<RapidResponse> {
+        @Override
+        public void onSuccess(@Nonnull final RapidResponse rapidResponse) {
+            for (final ViewChange change : rapidResponse.getSynchronizationResponse().getChangesList()) {
+                for (int i = 0; i < change.getNodeIdKeysCount(); i++) {
+                    joinerUuid.put(change.getNodeIdKeys(i), change.getNodeIdValues(i));
+                }
+                for (int i = 0; i < change.getMetadataKeysCount(); i++) {
+                    joinerMetadata.put(change.getMetadataKeys(i), change.getMetadataValues(i));
+                }
+                decideViewChange(change.getEndpointsList());
+            }
+        }
+
+        @Override
+        public void onFailure(final Throwable throwable) {
+            LOG.warn("Failed to synchronize view changes", throwable);
+
+        }
+    }
+
     interface ISettings {
         int getFailureDetectorIntervalInMs();
 
         int getBatchingWindowInMs();
+
+        int getMembershipViewUpdateTimeoutInMs();
+
+        boolean leaveOnMembershipViewUpdateTimeout();
     }
 }

--- a/rapid/src/main/java/com/vrg/rapid/MembershipView.java
+++ b/rapid/src/main/java/com/vrg/rapid/MembershipView.java
@@ -101,14 +101,15 @@ final class MembershipView {
     JoinStatusCode isSafeToJoin(final Endpoint node, final NodeId uuid) {
         rwLock.readLock().lock();
         try {
-            if (allNodes.contains(node)) {
-                return JoinStatusCode.HOSTNAME_ALREADY_IN_RING;
+            if (allNodes.contains(node) && identifiersSeen.contains(uuid)) {
+                return JoinStatusCode.SAME_NODE_ALREADY_IN_RING;
             }
-
             if (identifiersSeen.contains(uuid)) {
                 return JoinStatusCode.UUID_ALREADY_IN_RING;
             }
-
+            if (allNodes.contains(node)) {
+                return JoinStatusCode.HOSTNAME_ALREADY_IN_RING;
+            }
             return JoinStatusCode.SAFE_TO_JOIN;
         } finally {
             rwLock.readLock().unlock();

--- a/rapid/src/main/java/com/vrg/rapid/MembershipView.java
+++ b/rapid/src/main/java/com/vrg/rapid/MembershipView.java
@@ -42,7 +42,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  * every node (an observer) observers its successor (a subject) on each ring.
  */
 @ThreadSafe
-final class MembershipView {
+class MembershipView {
     private final int K;
     private static final LongHashFunction HASH_FUNCTION = LongHashFunction.xx(0);
     private final ReadWriteLock rwLock = new ReentrantReadWriteLock();

--- a/rapid/src/main/java/com/vrg/rapid/MessageBatcher.java
+++ b/rapid/src/main/java/com/vrg/rapid/MessageBatcher.java
@@ -1,0 +1,89 @@
+package com.vrg.rapid;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Collects messages to be sent in batches at a regular interval
+ *
+ * @param <T> the type of messages
+ */
+public abstract class MessageBatcher<T> {
+
+    private long lastEnqueueTimestamp = -1;
+    @GuardedBy("batchQueueLock")
+    private final LinkedBlockingQueue<T> sendQueue = new LinkedBlockingQueue<>();
+    private final Lock batchQueueLock = new ReentrantLock();
+    private final ScheduledExecutorService backgroundTasksExecutor;
+    @Nullable private ScheduledFuture<?> batchingJob;
+    private final int batchingWindowInMs;
+
+    public MessageBatcher(final SharedResources sharedResources, final int batchingWindowInMs) {
+        this.batchingWindowInMs = batchingWindowInMs;
+        this.backgroundTasksExecutor = sharedResources.getScheduledTasksExecutor();
+    }
+
+    /**
+     * Sends the batch of messages
+     */
+    public abstract void sendMessages(final List<T> messages);
+
+    /**
+     * Enqueue a messages to be sent in batch
+     */
+    public void enqueueMessage(final T msg) {
+        batchQueueLock.lock();
+        try {
+            lastEnqueueTimestamp = System.currentTimeMillis();
+            sendQueue.add(msg);
+        }
+        finally {
+            batchQueueLock.unlock();
+        }
+    }
+
+    public void start() {
+        batchingJob = this.backgroundTasksExecutor.scheduleAtFixedRate(
+                new BatchingJob(),0, batchingWindowInMs, TimeUnit.MILLISECONDS
+        );
+    }
+
+    public void stop() {
+        if (batchingJob != null) {
+            batchingJob.cancel(false);
+
+        }
+    }
+
+    class BatchingJob implements Runnable {
+        @Override
+        public void run() {
+            final ArrayList<T> messages = new ArrayList<>(sendQueue.size());
+            batchQueueLock.lock();
+            try {
+                // Wait one BATCHING_WINDOW_IN_MS since last add before sending out
+                if (!sendQueue.isEmpty() && lastEnqueueTimestamp > 0
+                        && (System.currentTimeMillis() - lastEnqueueTimestamp) >
+                        batchingWindowInMs) {
+                    final int numDrained = sendQueue.drainTo(messages);
+                    assert numDrained > 0;
+                }
+            } finally {
+                batchQueueLock.unlock();
+            }
+            if (!messages.isEmpty()) {
+                sendMessages(messages);
+            }
+
+        }
+    }
+
+}

--- a/rapid/src/main/java/com/vrg/rapid/Settings.java
+++ b/rapid/src/main/java/com/vrg/rapid/Settings.java
@@ -27,6 +27,8 @@ public final class Settings implements GrpcClient.ISettings, MembershipService.I
     private int failureDetectorIntervalInMs = MembershipService.DEFAULT_FAILURE_DETECTOR_INTERVAL_IN_MS;
     private int batchingWindowInMs = MembershipService.BATCHING_WINDOW_IN_MS;
     private long consensusFallbackTimeoutBaseDelayInMs = FastPaxos.BASE_DELAY;
+    private int membershipViewTimeoutInMs = MembershipService.MEMBERSHIP_VIEW_TIMEOUT_IN_MS;
+    private boolean leaveOnMembershipViewTimeout = MembershipService.LEAVE_ON_MEMBERSHIP_VIEW_TIMEOUT;
 
     /*
      * Settings from GrpcClient.ISettings
@@ -96,6 +98,25 @@ public final class Settings implements GrpcClient.ISettings, MembershipService.I
 
     public void setBatchingWindowInMs(final int batchingWindowInMs) {
         this.batchingWindowInMs = batchingWindowInMs;
+    }
+
+
+    @Override
+    public int getMembershipViewUpdateTimeoutInMs() {
+        return this.membershipViewTimeoutInMs;
+    }
+
+    public void setMembershipViewUpdateTimeoutInMs(final int membershipViewTimeoutInMs) {
+        this.membershipViewTimeoutInMs = membershipViewTimeoutInMs;
+    }
+
+    @Override
+    public boolean leaveOnMembershipViewUpdateTimeout() {
+        return leaveOnMembershipViewTimeout;
+    }
+
+    public void setLeaveOnMembershipViewTimeout(final boolean leaveOnMembershipViewTimeout) {
+        this.leaveOnMembershipViewTimeout = leaveOnMembershipViewTimeout;
     }
 
     /*

--- a/rapid/src/main/java/com/vrg/rapid/Settings.java
+++ b/rapid/src/main/java/com/vrg/rapid/Settings.java
@@ -26,6 +26,7 @@ public final class Settings implements GrpcClient.ISettings, MembershipService.I
     private int grpcProbeTimeoutMs = GrpcClient.DEFAULT_GRPC_PROBE_TIMEOUT;
     private int failureDetectorIntervalInMs = MembershipService.DEFAULT_FAILURE_DETECTOR_INTERVAL_IN_MS;
     private int batchingWindowInMs = MembershipService.BATCHING_WINDOW_IN_MS;
+    private int consensusBatchingWindowInMs = MembershipService.CONSENSUS_BATCHING_WINDOW_IN_MS;
     private long consensusFallbackTimeoutBaseDelayInMs = FastPaxos.BASE_DELAY;
     private int membershipViewTimeoutInMs = MembershipService.MEMBERSHIP_VIEW_TIMEOUT_IN_MS;
     private boolean leaveOnMembershipViewTimeout = MembershipService.LEAVE_ON_MEMBERSHIP_VIEW_TIMEOUT;
@@ -94,6 +95,14 @@ public final class Settings implements GrpcClient.ISettings, MembershipService.I
     @Override
     public int getBatchingWindowInMs() {
         return this.batchingWindowInMs;
+    }
+
+    public int getConsensusBatchingWindowInMs() {
+        return this.consensusBatchingWindowInMs;
+    }
+
+    public void setConsensusBatchingWindowInMs(final int consensusBatchingWindowInMs) {
+        this.consensusBatchingWindowInMs = consensusBatchingWindowInMs;
     }
 
     public void setBatchingWindowInMs(final int batchingWindowInMs) {

--- a/rapid/src/main/java/com/vrg/rapid/SharedResources.java
+++ b/rapid/src/main/java/com/vrg/rapid/SharedResources.java
@@ -43,6 +43,7 @@ public class SharedResources {
     private final ExecutorService clientChannelExecutor;
     private final ExecutorService protocolExecutor;
     private final ScheduledExecutorService scheduledTasksExecutor;
+    private final ScheduledExecutorService consensusSheduledTasksExecutor;
     private final Endpoint address;
 
     public SharedResources(final Endpoint address) {
@@ -53,6 +54,8 @@ public class SharedResources {
         this.protocolExecutor = Executors.newSingleThreadExecutor(newNamedThreadFactory("protocol", address));
         this.scheduledTasksExecutor = Executors.newSingleThreadScheduledExecutor(
                                                     newNamedThreadFactory("msbg", address));
+        this.consensusSheduledTasksExecutor = Executors.newSingleThreadScheduledExecutor(
+                                                    newNamedThreadFactory("cmsbg", address));
     }
 
     /**
@@ -99,6 +102,12 @@ public class SharedResources {
      */
     public ScheduledExecutorService getScheduledTasksExecutor() {
         return scheduledTasksExecutor;
+    }
+    /**
+     * Executes periodic background tasks in MembershipService.
+     */
+    public ScheduledExecutorService getConsensusScheduledTasksExecutor() {
+        return consensusSheduledTasksExecutor;
     }
 
     /**

--- a/rapid/src/main/java/com/vrg/rapid/Utils.java
+++ b/rapid/src/main/java/com/vrg/rapid/Utils.java
@@ -29,6 +29,7 @@ import com.vrg.rapid.pb.Phase1bMessage;
 import com.vrg.rapid.pb.Phase2aMessage;
 import com.vrg.rapid.pb.Phase2bMessage;
 import com.vrg.rapid.pb.ProbeMessage;
+import com.vrg.rapid.pb.BroadcastingMessage;
 import com.vrg.rapid.pb.ProbeResponse;
 import com.vrg.rapid.pb.RapidRequest;
 import com.vrg.rapid.pb.RapidResponse;
@@ -181,6 +182,10 @@ final class Utils {
         return RapidRequest.newBuilder().setPhase2BMessage(msg).build();
     }
 
+    static RapidRequest toRapidRequest(final BroadcastingMessage msg) {
+        return RapidRequest.newBuilder().setBroadcastingMessage(msg).build();
+    }
+
     static RapidResponse toRapidResponse(final JoinResponse msg) {
         return RapidResponse.newBuilder().setJoinResponse(msg).build();
     }
@@ -192,7 +197,6 @@ final class Utils {
     static RapidResponse toRapidResponse(final ProbeResponse msg) {
         return RapidResponse.newBuilder().setProbeResponse(msg).build();
     }
-
 
     /**
      * Used to order endpoints in the different rings.

--- a/rapid/src/main/java/com/vrg/rapid/Utils.java
+++ b/rapid/src/main/java/com/vrg/rapid/Utils.java
@@ -28,7 +28,6 @@ import com.vrg.rapid.pb.Phase1aMessage;
 import com.vrg.rapid.pb.Phase1bMessage;
 import com.vrg.rapid.pb.Phase2aMessage;
 import com.vrg.rapid.pb.Phase2bMessage;
-import com.vrg.rapid.pb.PreJoinMessage;
 import com.vrg.rapid.pb.ProbeMessage;
 import com.vrg.rapid.pb.ProbeResponse;
 import com.vrg.rapid.pb.RapidRequest;
@@ -150,10 +149,6 @@ final class Utils {
      * Helpers to avoid the boilerplate of constructing a new RapidRequest/RapidResponse for
      * every message we want to send out.
      */
-    static RapidRequest toRapidRequest(final PreJoinMessage msg) {
-        return RapidRequest.newBuilder().setPreJoinMessage(msg).build();
-    }
-
     static RapidRequest toRapidRequest(final JoinMessage msg) {
         return RapidRequest.newBuilder().setJoinMessage(msg).build();
     }

--- a/rapid/src/main/java/com/vrg/rapid/messaging/IBroadcaster.java
+++ b/rapid/src/main/java/com/vrg/rapid/messaging/IBroadcaster.java
@@ -15,16 +15,22 @@ package com.vrg.rapid.messaging;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import com.vrg.rapid.pb.Endpoint;
+import com.vrg.rapid.pb.Metadata;
 import com.vrg.rapid.pb.RapidRequest;
 import com.vrg.rapid.pb.RapidResponse;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Supports different broadcast implementations (eager flooding, gossip, etc.).
+ *
+ * The interface is optimized for performance
  */
 public interface IBroadcaster {
-    List<ListenableFuture<RapidResponse>> broadcast(RapidRequest rapidRequest);
+    List<ListenableFuture<RapidResponse>> broadcast(RapidRequest rapidRequest, long configurationId);
 
-    void setMembership(List<Endpoint> recipients);
+    void onNodeAdded(Endpoint node, Optional<Metadata> metadata);
+
+    void onNodeRemoved(Endpoint node);
 }

--- a/rapid/src/main/java/com/vrg/rapid/monitoring/IEdgeFailureDetectorFactory.java
+++ b/rapid/src/main/java/com/vrg/rapid/monitoring/IEdgeFailureDetectorFactory.java
@@ -30,5 +30,5 @@ import io.grpc.ExperimentalApi;
  */
 @ExperimentalApi
 public interface IEdgeFailureDetectorFactory {
-    Runnable createInstance(final Endpoint subject, final Runnable notifier);
+    Runnable createInstance(final Endpoint subject, final long configuraitonId, final Runnable notifier);
 }

--- a/rapid/src/main/java/com/vrg/rapid/monitoring/impl/PingPongFailureDetector.java
+++ b/rapid/src/main/java/com/vrg/rapid/monitoring/impl/PingPongFailureDetector.java
@@ -53,7 +53,7 @@ public class PingPongFailureDetector implements Runnable {
     // A cache for probe messages. Avoids creating an unnecessary copy of a probe message each time.
     private final RapidRequest probeMessage;
 
-    private PingPongFailureDetector(final Endpoint address, final Endpoint subject,
+    private PingPongFailureDetector(final Endpoint address, final Endpoint subject, final long configurationId,
                                     final IMessagingClient rpcClient, final Runnable notifier) {
         this.address = address;
         this.subject = subject;
@@ -62,7 +62,11 @@ public class PingPongFailureDetector implements Runnable {
         this.failureCount = new AtomicInteger(0);
         this.bootstrapResponseCount = new AtomicInteger(0);
         this.probeMessage = RapidRequest.newBuilder().setProbeMessage(
-                ProbeMessage.newBuilder().setSender(address).build()).build();
+                ProbeMessage.newBuilder()
+                        .setSender(address)
+                        .setObserverConfigurationId(configurationId)
+                        .build()
+        ).build();
     }
 
     // Executed at observer
@@ -134,8 +138,8 @@ public class PingPongFailureDetector implements Runnable {
         }
 
         @Override
-        public Runnable createInstance(final Endpoint subject, final Runnable notifier) {
-            return new PingPongFailureDetector(address, subject, messagingClient, notifier);
+        public Runnable createInstance(final Endpoint subject, final long configurationId, final Runnable notifier) {
+            return new PingPongFailureDetector(address, subject, configurationId, messagingClient, notifier);
         }
     }
 }

--- a/rapid/src/main/proto/rapid.proto
+++ b/rapid/src/main/proto/rapid.proto
@@ -30,7 +30,8 @@ message RapidRequest
         Phase2aMessage phase2aMessage = 7;
         Phase2bMessage phase2bMessage = 8;
         LeaveMessage leaveMessage = 9;
-        SynchronizationMessage synchronizationMessage = 10;
+        BroadcastingMessage broadcastingMessage = 10;
+        SynchronizationMessage synchronizationMessage = 11;
 
    }
 }
@@ -114,9 +115,13 @@ message Response
 
 message FastRoundPhase2bMessage
 {
-    Endpoint sender = 1;
-    int64 configurationId = 2;
-    repeated Endpoint endpoints = 3;
+    repeated Proposal proposals = 1;
+}
+
+message Proposal {
+    int64 configurationId = 1;
+    repeated Endpoint endpoints = 2;
+    bytes votes = 3;
 }
 
 
@@ -177,6 +182,25 @@ message LeaveMessage
 {
     Endpoint sender = 1;
 }
+
+// ******* Broadcasting protocol *******
+
+message BroadcastingMessage
+{
+    RapidRequest message = 1;
+    int64 configurationId = 2;
+    bool shouldDeliver = 3;
+}
+
+message BroadcastingResponse {
+    BroadcastingStatus status = 1;
+}
+
+enum BroadcastingStatus {
+    ACCEPTED = 0;
+    CONFIGURATION_CHANGED = 1;
+}
+
 
 // ******* Used by simple probing failure detector *******
 

--- a/rapid/src/main/proto/rapid.proto
+++ b/rapid/src/main/proto/rapid.proto
@@ -21,16 +21,15 @@ message Endpoint
 message RapidRequest
 {
    oneof content {
-        PreJoinMessage preJoinMessage = 1;
-        JoinMessage joinMessage = 2;
-        BatchedAlertMessage batchedAlertMessage = 3;
-        ProbeMessage probeMessage = 4;
-        FastRoundPhase2bMessage fastRoundPhase2bMessage = 5;
-        Phase1aMessage phase1aMessage = 6;
-        Phase1bMessage phase1bMessage = 7;
-        Phase2aMessage phase2aMessage = 8;
-        Phase2bMessage phase2bMessage = 9;
-        LeaveMessage leaveMessage = 10;
+        JoinMessage joinMessage = 1;
+        BatchedAlertMessage batchedAlertMessage = 2;
+        ProbeMessage probeMessage = 3;
+        FastRoundPhase2bMessage fastRoundPhase2bMessage = 4;
+        Phase1aMessage phase1aMessage = 5;
+        Phase1bMessage phase1bMessage = 6;
+        Phase2aMessage phase2aMessage = 7;
+        Phase2bMessage phase2bMessage = 8;
+        LeaveMessage leaveMessage = 9;
    }
 }
 
@@ -53,22 +52,11 @@ message NodeId
    int64 low = 2;
 }
 
-// TODO: JoinMessage and JoinResponse are overloaded because they are being used for phase 1 and 2 of the bootstrap.
-message PreJoinMessage
-{
-   Endpoint sender = 1;
-   NodeId nodeId = 2;
-   repeated int32 ringNumber = 3;
-   int64 configurationId = 4;
-}
-
 message JoinMessage
 {
    Endpoint sender = 1;
    NodeId nodeId = 2;
-   repeated int32 ringNumber = 3;
-   int64 configurationId = 4;
-   Metadata metadata = 5;
+   Metadata metadata = 3;
 }
 
 message JoinResponse
@@ -85,9 +73,8 @@ message JoinResponse
 enum JoinStatusCode {
     HOSTNAME_ALREADY_IN_RING = 0;
     UUID_ALREADY_IN_RING = 1;
-    SAFE_TO_JOIN = 2;
-    CONFIG_CHANGED = 3;
-    MEMBERSHIP_REJECTED = 4;
+    SAME_NODE_ALREADY_IN_RING = 2;
+    SAFE_TO_JOIN = 3;
 };
 
 // ******* Alert messages *******

--- a/rapid/src/main/proto/rapid.proto
+++ b/rapid/src/main/proto/rapid.proto
@@ -75,6 +75,7 @@ enum JoinStatusCode {
     UUID_ALREADY_IN_RING = 1;
     SAME_NODE_ALREADY_IN_RING = 2;
     SAFE_TO_JOIN = 3;
+    VIEW_CHANGE_IN_PROGRESS = 4;
 };
 
 // ******* Alert messages *******

--- a/rapid/src/main/proto/rapid.proto
+++ b/rapid/src/main/proto/rapid.proto
@@ -30,6 +30,8 @@ message RapidRequest
         Phase2aMessage phase2aMessage = 7;
         Phase2bMessage phase2bMessage = 8;
         LeaveMessage leaveMessage = 9;
+        SynchronizationMessage synchronizationMessage = 10;
+
    }
 }
 
@@ -40,6 +42,7 @@ message RapidResponse
         Response response = 2;
         ConsensusResponse consensusResponse = 3;
         ProbeResponse probeResponse = 4;
+        SynchronizationResponse synchronizationResponse = 5;
    }
 }
 
@@ -180,7 +183,7 @@ message LeaveMessage
 message ProbeMessage
 {
     Endpoint sender = 1;
-    repeated bytes payload = 3;
+    int64 observerConfigurationId = 2;
 }
 
 message ProbeResponse
@@ -192,3 +195,27 @@ enum NodeStatus {
     OK = 0;             // this is the default value
     BOOTSTRAPPING = 1;
 };
+
+// ******* Used by the anti-entropy mechanism *******
+
+message SynchronizationMessage
+{
+    Endpoint sender = 1;
+    int64 configurationId = 2;
+}
+
+message SynchronizationResponse
+{
+    Endpoint sender = 1;
+    repeated ViewChange changes = 2;
+}
+
+message ViewChange
+{
+    int64 configurationId = 1;
+    repeated Endpoint endpoints = 2;
+    repeated Endpoint nodeIdKeys = 3;
+    repeated NodeId nodeIdValues = 4;
+    repeated Endpoint metadataKeys = 5;
+    repeated Metadata metadataValues = 6;
+}

--- a/rapid/src/test/java/com/vrg/rapid/ClusterTest.java
+++ b/rapid/src/test/java/com/vrg/rapid/ClusterTest.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -42,6 +43,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -421,6 +423,100 @@ public class ClusterTest {
     }
 
     /**
+     * Check the anti-entropy mechanism that catches up members that have missed a consensus round
+     */
+    @Test(timeout = 50000)
+    public void missConsensusMessagesAndSync() throws IOException, InterruptedException {
+        useFastFailureDetectionTimeouts();
+        final int membershipViewUpdateTimeoutInMs = 5000;
+        settings.setMembershipViewUpdateTimeoutInMs(membershipViewUpdateTimeoutInMs);
+        final int numNodesPhase1 = 40;
+        final int numNodesPhase2 = 5;
+        final Endpoint seedEndpoint = Utils.hostFromParts("127.0.0.1", basePort);
+        createCluster(numNodesPhase1, seedEndpoint);
+        verifyCluster(numNodesPhase1);
+
+        // node that will miss consensus messages joins. needs to join now because of the way drop helpers work
+        final Endpoint staleNode = Utils.hostFromParts("127.0.0.1", portCounter.incrementAndGet());
+        dropFirstNAtServer(staleNode, 1000, RapidRequest.ContentCase.FASTROUNDPHASE2BMESSAGE);
+        extendCluster(staleNode, seedEndpoint);
+        waitAndVerifyAgreement(numNodesPhase1 + 1, 10, 2000);
+
+        extendCluster(numNodesPhase2, seedEndpoint);
+
+
+        final Map<Endpoint, Cluster> instancesToCheck = new HashMap<>(instances);
+        instancesToCheck.remove(staleNode);
+
+        final AtomicBoolean hasSynchronized = new AtomicBoolean(false);
+        instances.get(staleNode).registerSubscription(ClusterEvents.VIEW_CHANGE, (configurationId, statusChanges) -> {
+            hasSynchronized.set(true);
+        });
+
+        // the other nodes will see all nodes
+        waitAndVerifyAgreement(numNodesPhase1 + numNodesPhase2 + 1, 10, 2000, instancesToCheck);
+        assertTrue(instances.get(seedEndpoint).getMemberlist().contains(staleNode));
+
+        // the stale node will be out of date
+        assertEquals(numNodesPhase1 + 1, instances.get(staleNode).getMemberlist().size());
+
+        Thread.sleep(membershipViewUpdateTimeoutInMs);
+        assertTrue(hasSynchronized.get());
+
+        // all nodes should be in agreement
+        waitAndVerifyAgreement(numNodesPhase1 + numNodesPhase2 + 1, 5, 1000);
+    }
+
+
+    /**
+     * Check the anti-entropy mechanism that nudges members that have missed a consensus round to proactively leave
+     */
+    @Test(timeout = 40000)
+    public void missConsensusMessagesAndLeave() throws IOException, InterruptedException {
+        settings.setGrpcProbeTimeoutMs(300);
+        settings.setFailureDetectorIntervalInMs(50);
+        final int membershipViewUpdateTimeoutInMs = 5000;
+        settings.setMembershipViewUpdateTimeoutInMs(membershipViewUpdateTimeoutInMs);
+        settings.setLeaveOnMembershipViewTimeout(true);
+        final int numNodesPhase1 = 40;
+        final int numNodesPhase2 = 5;
+        final Endpoint seedEndpoint = Utils.hostFromParts("127.0.0.1", basePort);
+        createCluster(numNodesPhase1, seedEndpoint);
+        verifyCluster(numNodesPhase1);
+
+        // node that will miss consensus messages joins. needs to join now because of the way drop helpers work
+        final Endpoint staleNode = Utils.hostFromParts("127.0.0.1", portCounter.incrementAndGet());
+        dropFirstNAtServer(staleNode, 1000, RapidRequest.ContentCase.FASTROUNDPHASE2BMESSAGE);
+        extendCluster(staleNode, seedEndpoint);
+        waitAndVerifyAgreement(numNodesPhase1 + 1, 10, 2000);
+
+        extendCluster(numNodesPhase2, seedEndpoint);
+
+        final Map<Endpoint, Cluster> instancesToCheck = new HashMap<>(instances);
+        instancesToCheck.remove(staleNode);
+
+        final AtomicBoolean hasLeft = new AtomicBoolean(false);
+        instances.get(staleNode).registerSubscription(ClusterEvents.KICKED, (configurationId, statusChanges) -> {
+            hasLeft.set(true);
+            instances.get(staleNode).shutdown();
+            instances.remove(staleNode);
+        });
+
+        // the other nodes will see all nodes
+        waitAndVerifyAgreement(numNodesPhase1 + numNodesPhase2 + 1, 10, 2000, instancesToCheck);
+        assertTrue(instances.get(seedEndpoint).getMemberlist().contains(staleNode));
+
+        // the stale node will be out of date
+        assertEquals(numNodesPhase1 + 1, instances.get(staleNode).getMemberlist().size());
+
+        Thread.sleep(membershipViewUpdateTimeoutInMs);
+        assertTrue(hasLeft.get());
+
+        // the stale node having left proactively, it should no longer be part of the membership on the other nodes
+        waitAndVerifyAgreement(numNodesPhase1 + numNodesPhase2, 20, 1000);
+    }
+
+    /**
      * This test starts with a node joining a 1 node cluster. We drop phase 2 messages at the seed
      * such that RPC-level retries of the first join attempt eventually get through.
      */
@@ -732,8 +828,12 @@ public class ClusterTest {
      * @param expectedSize expected size of each cluster
      */
     private void verifyCluster(final int expectedSize) {
-        final List<Endpoint> any = instances.entrySet().iterator().next().getValue().getMemberlist();
-        for (final Cluster cluster : instances.values()) {
+        verifyCluster(expectedSize, instances);
+    }
+
+    private void verifyCluster(final int expectedSize, final Map<Endpoint, Cluster> instancesToCheck) {
+        final List<Endpoint> any = instancesToCheck.entrySet().iterator().next().getValue().getMemberlist();
+        for (final Cluster cluster : instancesToCheck.values()) {
             assertEquals(cluster.toString(), expectedSize, cluster.getMemberlist().size());
             assertEquals(cluster.getMemberlist(), any);
             if (addMetadata) {
@@ -741,6 +841,7 @@ public class ClusterTest {
             }
         }
     }
+
 
     /**
      * Verify that all nodes in the cluster are of size {@code expectedSize} and have an identical
@@ -773,11 +874,17 @@ public class ClusterTest {
      */
     private void waitAndVerifyAgreement(final int expectedSize, final int maxTries, final int intervalInMs)
             throws InterruptedException {
+        waitAndVerifyAgreement(expectedSize, maxTries, intervalInMs, instances);
+    }
+
+    private void waitAndVerifyAgreement(final int expectedSize, final int maxTries, final int intervalInMs,
+                                        final Map<Endpoint, Cluster> instancesToCheck)
+            throws InterruptedException {
         int tries = maxTries;
         while (--tries > 0) {
             boolean ready = true;
-            final List<Endpoint> any = instances.entrySet().iterator().next().getValue().getMemberlist();
-            for (final Cluster cluster : instances.values()) {
+            final List<Endpoint> any = instancesToCheck.entrySet().iterator().next().getValue().getMemberlist();
+            for (final Cluster cluster : instancesToCheck.values()) {
                 if (!(cluster.getMemberlist().size() == expectedSize
                         && cluster.getMemberlist().equals(any))) {
                     ready = false;
@@ -790,8 +897,9 @@ public class ClusterTest {
             }
         }
 
-        verifyCluster(expectedSize);
+        verifyCluster(expectedSize, instancesToCheck);
     }
+
 
     // Helper that provides a list of N random nodes that have already been added to the instances map
     private Set<Endpoint> getRandomHosts(final int N) {

--- a/rapid/src/test/java/com/vrg/rapid/ClusterTest.java
+++ b/rapid/src/test/java/com/vrg/rapid/ClusterTest.java
@@ -263,7 +263,7 @@ public class ClusterTest {
         for (int i = 0; i < phaseTwojoiners; i++) {
             extendCluster(1, seedEndpoint);
         }
-        waitAndVerifyAgreement(numNodes + phaseOneJoiners + phaseTwojoiners, 20, 1000);
+        waitAndVerifyAgreement(numNodes + phaseOneJoiners + phaseTwojoiners, 20, 1500);
         verifyNumClusterInstances(numNodes + phaseOneJoiners + phaseTwojoiners);
     }
 

--- a/rapid/src/test/java/com/vrg/rapid/ClusterTest.java
+++ b/rapid/src/test/java/com/vrg/rapid/ClusterTest.java
@@ -31,6 +31,7 @@ import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -142,6 +143,68 @@ public class ClusterTest {
         extendCluster(1, seedEndpoint);
         verifyCluster(2);
     }
+
+    /**
+     * A node attempts to join two different seeds in a very short time-frame.
+     * Rather than be allowed to join twice, the client API disallows this behavior
+     */
+    @Test(timeout = 30000)
+    public void singleNodeJoinsTwoSeeds() throws Exception {
+
+        // set up two nodes
+        final Endpoint seedEndpoint = Utils.hostFromParts("127.0.0.1", basePort);
+        createCluster(1, seedEndpoint);
+        verifyCluster(1);
+        extendCluster(1, seedEndpoint);
+        verifyCluster(2);
+
+        final Endpoint joiningEndpoint = Utils.hostFromParts("127.0.0.1", portCounter.incrementAndGet());
+
+        final ExecutorService executor = Executors.newWorkStealingPool(2);
+        final CountDownLatch latch = new CountDownLatch(2);
+
+        final Iterator<Endpoint> seedIterator = instances.keySet().iterator();
+        final Endpoint seed1 = seedIterator.next();
+        final Endpoint seed2 = seedIterator.next();
+        try {
+            executor.execute(() -> {
+                final Cluster.Builder builder = buildCluster(joiningEndpoint);
+
+                // first join attempt
+                try {
+                    final Cluster joiner = builder.join(seed1);
+                    instances.put(joiningEndpoint, joiner);
+                } catch (final InterruptedException | IOException e) {
+                    e.printStackTrace();
+                    fail();
+                } finally {
+                    latch.countDown();
+                }
+
+                // client tries to join again while a join is already in progress at another seed
+                // this should fail
+                try {
+                    builder.join(seed2);
+                    fail();
+                } catch (final InterruptedException | IOException e) {
+                    // that's what we want
+                } finally {
+                    latch.countDown();
+                }
+            });
+
+            latch.await();
+        } catch (final InterruptedException e) {
+            e.printStackTrace();
+            fail();
+        } finally {
+            executor.shutdown();
+        }
+
+        waitAndVerifyAgreement(3, 10, 1000);
+
+    }
+
 
     /**
      * Test with K nodes joining the network through a single seed.

--- a/rapid/src/test/java/com/vrg/rapid/EndpointCountingGrpcClient.java
+++ b/rapid/src/test/java/com/vrg/rapid/EndpointCountingGrpcClient.java
@@ -1,0 +1,35 @@
+package com.vrg.rapid;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import com.vrg.rapid.messaging.impl.GrpcClient;
+import com.vrg.rapid.pb.Endpoint;
+import com.vrg.rapid.pb.RapidRequest;
+import com.vrg.rapid.pb.RapidResponse;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class EndpointCountingGrpcClient extends GrpcClient {
+
+    private final Set<Endpoint> seenEndpoints = ConcurrentHashMap.newKeySet();
+
+    EndpointCountingGrpcClient(final Endpoint address, final ISettings settings) {
+        super(address, settings);
+    }
+
+    @Override
+    public ListenableFuture<RapidResponse> sendMessage(final Endpoint remote, final RapidRequest msg) {
+        seenEndpoints.add(remote);
+        return super.sendMessage(remote, msg);
+    }
+
+    @Override
+    public ListenableFuture<RapidResponse> sendMessageBestEffort(final Endpoint remote, final RapidRequest msg) {
+        seenEndpoints.add(remote);
+        return super.sendMessageBestEffort(remote, msg);
+    }
+
+    public int getEndpointCount() {
+        return seenEndpoints.size();
+    }
+}

--- a/rapid/src/test/java/com/vrg/rapid/FastPaxosWithoutFallbackTests.java
+++ b/rapid/src/test/java/com/vrg/rapid/FastPaxosWithoutFallbackTests.java
@@ -13,11 +13,14 @@
 
 package com.vrg.rapid;
 
+import com.google.protobuf.ByteString;
+import com.vrg.rapid.messaging.IBroadcaster;
 import com.vrg.rapid.messaging.IMessagingClient;
 import com.vrg.rapid.messaging.impl.GrpcClient;
 import com.vrg.rapid.monitoring.impl.PingPongFailureDetector;
 import com.vrg.rapid.pb.Endpoint;
 import com.vrg.rapid.pb.FastRoundPhase2bMessage;
+import com.vrg.rapid.pb.Proposal;
 import com.vrg.rapid.pb.RapidRequest;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
@@ -29,6 +32,7 @@ import org.junit.runner.RunWith;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.BitSet;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
@@ -70,15 +74,17 @@ public class FastPaxosWithoutFallbackTests {
         final MembershipService service = createAndStartMembershipService(node, view);
         assertEquals(N, service.getMembershipSize());
         final long currentId = view.getCurrentConfigurationId();
-        final FastRoundPhase2bMessage.Builder proposal =
-                getProposal(currentId, Collections.singletonList(proposalNode));
-
         for (int i = 0; i < quorum - 1; i++) {
-            service.handleMessage(asRapidMessage(proposal.setSender(addrForBase(i)).build())).get();
+            final FastRoundPhase2bMessage.Builder proposal =
+                    getProposal(addrForBase(serverPort + i), currentId, view.getRing(0),
+                            Collections.singletonList(proposalNode));
+            service.handleMessage(asRapidMessage(proposal.build())).get();
             assertEquals(N, service.getMembershipSize());
         }
-        service.handleMessage(asRapidMessage(proposal.setSender(addrForBase(quorum - 1)).build()))
-               .get();
+        final FastRoundPhase2bMessage.Builder proposal =
+                getProposal(addrForBase(serverPort + quorum - 1), currentId, view.getRing(0),
+                        Collections.singletonList(proposalNode));
+        service.handleMessage(asRapidMessage(proposal.build())).get();
         assertEquals(N - 1, service.getMembershipSize());
     }
 
@@ -109,20 +115,26 @@ public class FastPaxosWithoutFallbackTests {
         assertEquals(N, service.getMembershipSize());
         final long currentId = view.getCurrentConfigurationId();
 
-        final FastRoundPhase2bMessage.Builder proposal =
-                getProposal(currentId, Collections.singletonList(proposalNode));
-        final FastRoundPhase2bMessage.Builder proposalConflict =
-                getProposal(currentId, Collections.singletonList(proposalNodeConflict));
         for (int i = 0; i < numConflicts; i++) {
-            service.handleMessage(asRapidMessage(proposalConflict.setSender(addrForBase(i)).build())).get();
+            final FastRoundPhase2bMessage.Builder proposalConflict =
+                    getProposal(addrForBase(serverPort + i), currentId, view.getRing(0),
+                            Collections.singletonList(proposalNodeConflict));
+            service.handleMessage(asRapidMessage(proposalConflict.build())).get();
             assertEquals(N, service.getMembershipSize());
         }
         final int nonConflictCount = Math.min(numConflicts + quorum - 1, N - 1);
         for (int i = numConflicts; i < nonConflictCount; i++) {
-            service.handleMessage(asRapidMessage(proposal.setSender(addrForBase(i)).build())).get();
+            final FastRoundPhase2bMessage.Builder proposal =
+                    getProposal(addrForBase(serverPort + i), currentId, view.getRing(0),
+                            Collections.singletonList(proposalNode));
+            service.handleMessage(asRapidMessage(proposal.build())).get();
             assertEquals(N, service.getMembershipSize());
         }
-        service.handleMessage(asRapidMessage(proposal.setSender(addrForBase(nonConflictCount)).build())).get();
+        final FastRoundPhase2bMessage.Builder proposal =
+                getProposal(addrForBase(serverPort + nonConflictCount), currentId, view.getRing(0),
+                        Collections.singletonList(proposalNode));
+
+        service.handleMessage(asRapidMessage(proposal.build())).get();
         assertEquals(changeExpected ? N - 1 : N, service.getMembershipSize());
     }
 
@@ -156,8 +168,10 @@ public class FastPaxosWithoutFallbackTests {
                 new MultiNodeCutDetector(K, H, L);
         final SharedResources resources = new SharedResources(serverAddr);
         final IMessagingClient client = new GrpcClient(serverAddr);
+        final IBroadcaster broadcaster = new UnicastToAllBroadcaster(client);
         final MembershipService service = new MembershipService(serverAddr, cutDetector, view,
-                resources, new Settings(), client, new PingPongFailureDetector.Factory(serverAddr, client));
+                resources, new Settings(), client, broadcaster,
+                new PingPongFailureDetector.Factory(serverAddr, client));
         services.add(service);
         return service;
     }
@@ -176,11 +190,18 @@ public class FastPaxosWithoutFallbackTests {
     /**
      * Returns a proposal message without the sender set.
      */
-    private FastRoundPhase2bMessage.Builder getProposal(final long currentConfigurationId,
+    private FastRoundPhase2bMessage.Builder getProposal(final Endpoint node,
+                                                        final long currentConfigurationId,
+                                                        final List<Endpoint> memberList,
                                                         final List<Endpoint> proposal) {
+        final BitSet votes = new BitSet(memberList.size());
+        votes.set(memberList.indexOf(node));
         return FastRoundPhase2bMessage.newBuilder()
-                .setConfigurationId(currentConfigurationId)
-                .addAllEndpoints(proposal);
+                .addProposals(Proposal.newBuilder()
+                    .addAllEndpoints(proposal)
+                    .setConfigurationId(currentConfigurationId)
+                    .setVotes(ByteString.copyFrom(votes.toByteArray()))
+                    .build());
     }
 
     private Endpoint addrForBase(final int port) {

--- a/rapid/src/test/java/com/vrg/rapid/MessagingTest.java
+++ b/rapid/src/test/java/com/vrg/rapid/MessagingTest.java
@@ -56,6 +56,7 @@ public class MessagingTest {
     private static final int L = 3;
 
     private static final int SERVER_PORT_BASE = 1134;
+    private static final String LOCALHOST = "localhost";
     private static final String LOCALHOST_IP = "127.0.0.1";
     private final List<IMessagingServer> rpcServers = new ArrayList<>();
     private final List<MembershipService> services = new ArrayList<>();
@@ -127,7 +128,9 @@ public class MessagingTest {
         // Try again with a different port, this should fail because we're using the same
         // uuid as the server.
         final int clientPort2 = 1235;
-        final Endpoint clientAddr2 = Utils.hostFromParts(LOCALHOST_IP, clientPort2);
+        // we need another address than 127.0.0.1 or else we'll get a valid response from the SAME_NODE_ALREADY_IN_RING
+        // mechanism
+        final Endpoint clientAddr2 = Utils.hostFromParts(LOCALHOST, clientPort2);
         final GrpcClient client2 = new GrpcClient(clientAddr2);
         final JoinResponse result2 = sendJoinMessage(client2, serverAddr, clientAddr2, nodeIdentifier);
         assertNotNull(result2);
@@ -405,4 +408,5 @@ public class MessagingTest {
                                                             .setNodeId(identifier).build());
         return client.sendMessage(serverAddr, joinMessage).get().getJoinResponse();
     }
+
 }

--- a/rapid/src/test/java/com/vrg/rapid/MessagingTest.java
+++ b/rapid/src/test/java/com/vrg/rapid/MessagingTest.java
@@ -13,7 +13,6 @@
 
 package com.vrg.rapid;
 
-import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.vrg.rapid.messaging.IMessagingClient;
@@ -28,7 +27,6 @@ import com.vrg.rapid.pb.JoinResponse;
 import com.vrg.rapid.pb.JoinStatusCode;
 import com.vrg.rapid.pb.NodeId;
 import com.vrg.rapid.pb.NodeStatus;
-import com.vrg.rapid.pb.PreJoinMessage;
 import com.vrg.rapid.pb.ProbeMessage;
 import com.vrg.rapid.pb.RapidRequest;
 import com.vrg.rapid.pb.RapidResponse;
@@ -39,14 +37,10 @@ import org.junit.Test;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
-import java.util.stream.Collectors;
 
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
@@ -99,11 +93,11 @@ public class MessagingTest {
 
         final Endpoint clientAddr = Utils.hostFromParts(LOCALHOST_IP, clientPort);
         final GrpcClient client = new GrpcClient(clientAddr);
-        final JoinResponse result = sendPreJoinMessage(client, serverAddr, clientAddr,
+        final JoinResponse result = sendJoinMessage(client, serverAddr, clientAddr,
                                                        Utils.nodeIdFromUUID(UUID.randomUUID()));
         assertNotNull(result);
         assertEquals(JoinStatusCode.SAFE_TO_JOIN, result.getStatusCode());
-        assertEquals(K, result.getEndpointsCount());
+        assertEquals(2, result.getEndpointsCount());
     }
 
     /**
@@ -123,11 +117,11 @@ public class MessagingTest {
         // Try with the same host details as the server
         final Endpoint clientAddr1 = Utils.hostFromParts(LOCALHOST_IP, serverPort);
         final GrpcClient client1 = new GrpcClient(clientAddr1);
-        final JoinResponse result1 = sendPreJoinMessage(client1, serverAddr, clientAddr1,
+        final JoinResponse result1 = sendJoinMessage(client1, serverAddr, clientAddr1,
                                                              Utils.nodeIdFromUUID(UUID.randomUUID()));
         assertNotNull(result1);
         assertEquals(JoinStatusCode.HOSTNAME_ALREADY_IN_RING, result1.getStatusCode());
-        assertEquals(K, result1.getEndpointsCount());
+        assertEquals(0, result1.getEndpointsCount());
         assertEquals(0, result1.getIdentifiersCount());
 
         // Try again with a different port, this should fail because we're using the same
@@ -135,131 +129,11 @@ public class MessagingTest {
         final int clientPort2 = 1235;
         final Endpoint clientAddr2 = Utils.hostFromParts(LOCALHOST_IP, clientPort2);
         final GrpcClient client2 = new GrpcClient(clientAddr2);
-        final JoinResponse result2 = sendPreJoinMessage(client2, serverAddr, clientAddr2, nodeIdentifier);
+        final JoinResponse result2 = sendJoinMessage(client2, serverAddr, clientAddr2, nodeIdentifier);
         assertNotNull(result2);
         assertEquals(JoinStatusCode.UUID_ALREADY_IN_RING, result2.getStatusCode());
         assertEquals(0, result2.getEndpointsCount());
         assertEquals(0, result2.getIdentifiersCount());
-    }
-
-    /**
-     * A node in a cluster gets a join request from a peer with non conflicting
-     * hostnames and UUID. Verify the cluster Settings relayed to
-     * the requesting peer.
-     */
-    @Test
-    public void joinWithMultipleNodesCheckConfiguration()
-            throws InterruptedException, IOException, MembershipView.NodeAlreadyInRingException, ExecutionException {
-        final NodeId nodeIdentifier = Utils.nodeIdFromUUID(UUID.randomUUID());
-        final int numNodes = 1000;
-        final Endpoint serverAddr = Utils.hostFromParts(LOCALHOST_IP, SERVER_PORT_BASE);
-        final MembershipView membershipView = new MembershipView(K);
-        membershipView.ringAdd(serverAddr, nodeIdentifier);
-        for (int i = 1; i < numNodes; i++) {
-            membershipView.ringAdd(Utils.hostFromParts(LOCALHOST_IP, SERVER_PORT_BASE + i),
-                                   Utils.nodeIdFromUUID(UUID.randomUUID()));
-        }
-        createAndStartMembershipService(serverAddr, membershipView);
-
-        final int clientPort = SERVER_PORT_BASE - 1;
-        final Endpoint joinerAddr = Utils.hostFromParts(LOCALHOST_IP, clientPort);
-        final GrpcClient joinerClient = new GrpcClient(joinerAddr);
-        final JoinResponse phaseOneResult = sendPreJoinMessage(joinerClient, serverAddr, joinerAddr,
-                                                               Utils.nodeIdFromUUID(UUID.randomUUID()));
-        assertNotNull(phaseOneResult);
-        assertEquals(JoinStatusCode.SAFE_TO_JOIN, phaseOneResult.getStatusCode());
-        assertEquals(K, phaseOneResult.getEndpointsCount()); // this is the observer list
-
-        // Verify that the observers retrieved from the seed are the same
-        final List<Endpoint> hostsAtClient = phaseOneResult.getEndpointsList();
-        final List<Endpoint> observersOriginal = membershipView.getExpectedObserversOf(joinerAddr);
-
-        final Iterator iter1 = hostsAtClient.iterator();
-        final Iterator iter2 = observersOriginal.iterator();
-        for (int i = 0; i < hostsAtClient.size(); i++) {
-            assertEquals(iter1.next(), iter2.next());
-        }
-    }
-
-    /**
-     * A node in a cluster gets a join request from a peer that is already part of the membership.
-     * If the joiner is in the current configuration, it should get back the full configuration.
-     */
-    @Test
-    public void joinWithMultipleNodesCheckRace()
-            throws InterruptedException, IOException, MembershipView.NodeAlreadyInRingException, ExecutionException {
-        // Initialize 10 node cluster
-        final int numNodes = 10;
-        final Endpoint serverAddr = Utils.hostFromParts(LOCALHOST_IP, SERVER_PORT_BASE);
-        for (int i = 0; i < numNodes; i++) {
-            final MembershipView mview = new MembershipView(K);
-            for (int j = 0; j < numNodes; j++) {
-                mview.ringAdd(Utils.hostFromParts(LOCALHOST_IP, SERVER_PORT_BASE + j),
-                        Utils.nodeIdFromUUID(new UUID(0, j)));
-            }
-            createAndStartMembershipService(Utils.hostFromParts(LOCALHOST_IP, SERVER_PORT_BASE + i), mview);
-        }
-
-        // Join protocol starts here
-        final int clientPort = SERVER_PORT_BASE - 1;
-        final Endpoint joinerAddr = Utils.hostFromParts(LOCALHOST_IP, clientPort);
-        final GrpcClient joinerClient = new GrpcClient(joinerAddr);
-        final NodeId uuid = Utils.nodeIdFromUUID(UUID.randomUUID());
-        final JoinResponse phaseOneResult = sendPreJoinMessage(joinerClient, serverAddr, joinerAddr, uuid);
-
-        assertNotNull(phaseOneResult);
-        assertEquals(JoinStatusCode.SAFE_TO_JOIN, phaseOneResult.getStatusCode());
-        assertEquals(K, phaseOneResult.getEndpointsCount()); // this is the observer list
-
-        // Verify that the observers retrieved from the seed are the same
-        final List<Endpoint> hostsAtClient = phaseOneResult.getEndpointsList();
-        final Map<Endpoint, List<Integer>> ringNumbersPerObserver = new HashMap<>(K);
-
-        // Batch together requests to the same node.
-        int ringNumber = 0;
-        for (final Endpoint observer: hostsAtClient) {
-            ringNumbersPerObserver.computeIfAbsent(observer, k -> new ArrayList<>()).add(ringNumber);
-            ringNumber++;
-        }
-
-        // Try #1: successfully join here.
-        final List<ListenableFuture<RapidResponse>> responseFutures = new ArrayList<>();
-        for (final Map.Entry<Endpoint, List<Integer>> entry: ringNumbersPerObserver.entrySet()) {
-            final RapidRequest msg = Utils.toRapidRequest(JoinMessage.newBuilder()
-                    .setSender(joinerAddr)
-                    .setNodeId(uuid)
-                    .setConfigurationId(phaseOneResult.getConfigurationId())
-                    .addAllRingNumber(entry.getValue()).build());
-            final ListenableFuture<RapidResponse> call = joinerClient.sendMessage(entry.getKey(), msg);
-            responseFutures.add(call);
-        }
-        final List<JoinResponse> joinResponses = Futures.successfulAsList(responseFutures).get()
-                .stream().filter(Objects::nonNull).map(RapidResponse::getJoinResponse).collect(Collectors.toList());
-        assertEquals(ringNumbersPerObserver.size(), joinResponses.size());
-
-        for (final JoinResponse response: joinResponses) {
-            assertEquals(JoinStatusCode.SAFE_TO_JOIN, response.getStatusCode());
-        }
-
-        // Try #2. Should get back the full configuration from all nodes.
-        final List<ListenableFuture<RapidResponse>> retryFutures = new ArrayList<>();
-        for (final Map.Entry<Endpoint, List<Integer>> entry: ringNumbersPerObserver.entrySet()) {
-            final RapidRequest msg = Utils.toRapidRequest(JoinMessage.newBuilder()
-                    .setSender(joinerAddr)
-                    .setNodeId(uuid)
-                    .setConfigurationId(phaseOneResult.getConfigurationId())
-                    .addAllRingNumber(entry.getValue()).build());
-            final ListenableFuture<RapidResponse> call = joinerClient.sendMessage(entry.getKey(), msg);
-            retryFutures.add(call);
-        }
-        final List<JoinResponse> retriedJoinResponses = Futures.successfulAsList(retryFutures).get()
-                .stream().map(RapidResponse::getJoinResponse).collect(Collectors.toList());
-        assertEquals(ringNumbersPerObserver.size(), retriedJoinResponses.size());
-
-        for (final JoinResponse response: retriedJoinResponses) {
-            assertEquals(JoinStatusCode.SAFE_TO_JOIN, response.getStatusCode());
-            assertEquals(numNodes + 1, response.getEndpointsCount());
-        }
     }
 
     /**
@@ -278,19 +152,19 @@ public class MessagingTest {
         final Endpoint joinerAddress = Utils.hostFromParts(LOCALHOST_IP, clientPort);
         final IMessagingClient messagingClient = new GrpcClient(joinerAddress);
         final NodeId joinerUuid = Utils.nodeIdFromUUID(UUID.randomUUID());
-        final JoinResponse response = sendPreJoinMessage(messagingClient, serverAddr, joinerAddress, joinerUuid);
+        final JoinResponse response = sendJoinMessage(messagingClient, serverAddr, joinerAddress, joinerUuid);
         assertNotNull(response);
         assertEquals(JoinStatusCode.SAFE_TO_JOIN, response.getStatusCode());
-        assertEquals(K, response.getEndpointsCount());
+        assertEquals(2, response.getEndpointsCount());
         assertEquals(response.getConfigurationId(), membershipView.getCurrentConfigurationId());
 
         // Verify that the hostnames retrieved at the joining peer
         // matches that of the seed node.
-        final List<Endpoint> observerList = response.getEndpointsList();
+        final List<Endpoint> memberList = response.getEndpointsList();
 
-        final Iterator<Endpoint> iterJoiner = observerList.iterator();
-        final Iterator<Endpoint> iterSeed = membershipView.getExpectedObserversOf(joinerAddress).iterator();
-        for (int i = 0; i < K; i++) {
+        final Iterator<Endpoint> iterJoiner = memberList.iterator();
+        final Iterator<Endpoint> iterSeed = membershipView.getRing(0).iterator();
+        for (int i = 0; i < 2; i++) {
             assertEquals(iterJoiner.next(), iterSeed.next());
         }
     }
@@ -312,19 +186,19 @@ public class MessagingTest {
         final Endpoint joinerAddress = Utils.hostFromParts(LOCALHOST_IP, clientPort);
         final IMessagingClient messagingClient = new GrpcClient(joinerAddress);
         final NodeId joinerUuid = Utils.nodeIdFromUUID(UUID.randomUUID());
-        final JoinResponse response = sendPreJoinMessage(messagingClient, serverAddr, joinerAddress, joinerUuid);
+        final JoinResponse response = sendJoinMessage(messagingClient, serverAddr, joinerAddress, joinerUuid);
         assertNotNull(response);
         assertEquals(JoinStatusCode.SAFE_TO_JOIN, response.getStatusCode());
-        assertEquals(K, response.getEndpointsCount());
+        assertEquals(2, response.getEndpointsCount());
         assertEquals(response.getConfigurationId(), membershipView.getCurrentConfigurationId());
 
         // Verify that the hostnames retrieved at the joining peer
         // matches that of the seed node.
-        final List<Endpoint> observerList = response.getEndpointsList();
+        final List<Endpoint> memberList = response.getEndpointsList();
 
-        final Iterator<Endpoint> iterJoiner = observerList.iterator();
-        final Iterator<Endpoint> iterSeed = membershipView.getExpectedObserversOf(joinerAddress).iterator();
-        for (int i = 0; i < K; i++) {
+        final Iterator<Endpoint> iterJoiner = memberList.iterator();
+        final Iterator<Endpoint> iterSeed = membershipView.getRing(0).iterator();
+        for (int i = 0; i < 2; i++) {
             assertEquals(iterJoiner.next(), iterSeed.next());
         }
 
@@ -523,12 +397,12 @@ public class MessagingTest {
         services.add(service);
     }
 
-    private JoinResponse sendPreJoinMessage(final IMessagingClient client, final Endpoint serverAddr,
-                                            final Endpoint clientAddr, final NodeId identifier)
+    private JoinResponse sendJoinMessage(final IMessagingClient client, final Endpoint serverAddr,
+                                         final Endpoint clientAddr, final NodeId identifier)
             throws ExecutionException, InterruptedException {
-        final RapidRequest preJoinMessage = Utils.toRapidRequest(PreJoinMessage.newBuilder()
+        final RapidRequest joinMessage = Utils.toRapidRequest(JoinMessage.newBuilder()
                                                             .setSender(clientAddr)
                                                             .setNodeId(identifier).build());
-        return client.sendMessage(serverAddr, preJoinMessage).get().getJoinResponse();
+        return client.sendMessage(serverAddr, joinMessage).get().getJoinResponse();
     }
 }

--- a/rapid/src/test/java/com/vrg/rapid/StaticFailureDetector.java
+++ b/rapid/src/test/java/com/vrg/rapid/StaticFailureDetector.java
@@ -52,7 +52,8 @@ class StaticFailureDetector implements Runnable {
         }
 
         @Override
-        public Runnable createInstance(final Endpoint observer, final Runnable notification) {
+        public Runnable createInstance(final Endpoint observer, final long configurationId,
+                                       final Runnable notification) {
             return new StaticFailureDetector(observer, notification, blackList);
         }
 

--- a/rapid/src/test/java/com/vrg/rapid/SubscriptionsTest.java
+++ b/rapid/src/test/java/com/vrg/rapid/SubscriptionsTest.java
@@ -197,6 +197,7 @@ public class SubscriptionsTest {
         // after it, as well as the notification from its own initialization
         assertEquals(numNodes + 1, seedCb1.numTimesCalled());
         testNodeStatus(seedCb1.getNotificationLog(), EdgeStatus.UP);
+        Thread.sleep(2000);
         for (int i = 0; i < numNodes; i++) {
             assertEquals(numNodes - i, callbacks.get(i).numTimesCalled());
             assertEquals(numNodes - i, callbacks.get(i).getNotificationLog().size());

--- a/rapid/src/test/java/com/vrg/rapid/TestMembershipView.java
+++ b/rapid/src/test/java/com/vrg/rapid/TestMembershipView.java
@@ -1,0 +1,31 @@
+package com.vrg.rapid;
+
+import com.vrg.rapid.pb.Endpoint;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class TestMembershipView extends MembershipView {
+
+    private AtomicBoolean shouldWait = new AtomicBoolean(false);
+
+    public TestMembershipView(final int K) {
+        super(K);
+    }
+
+    public void toggleWait() {
+        final boolean current = shouldWait.get();
+        shouldWait.set(!current);
+    }
+
+    @Override
+    boolean isHostPresent(final Endpoint address) {
+        try {
+            if (shouldWait.get()) {
+                Thread.sleep(200);
+            }
+        } catch (final InterruptedException e) {
+            e.printStackTrace();
+        }
+        return super.isHostPresent(address);
+    }
+}


### PR DESCRIPTION
This PR is cased on the `simplify-join` and `anti-entropy` branches.

It introduces an experimental broadcasting mechanism based on consistent hashing of recipients. This approach allows to scale to a large quantity of nodes (at least 10000) under the correct conditions. Indeed, this strategy does not preserve message ordering, which is an issue as the protocol expects alerts to be received before consensus messages (there's no re-ordering mechanism in place).

There is a change to the `IBroadcaster` API related to the performance of updating the list of recipients when many nodes are part of the cluster (it would be wasteful to add the entire membership list rather than add / remove affected nodes for each round).