### PR TITLE
Migrate subscriptions to a ClusterStatusChange API

### DIFF
--- a/examples/src/main/java/com/vrg/standalone/StandaloneAgent.java
+++ b/examples/src/main/java/com/vrg/standalone/StandaloneAgent.java
@@ -15,7 +15,7 @@ package com.vrg.standalone;
 
 import com.google.common.net.HostAndPort;
 import com.vrg.rapid.Cluster;
-import com.vrg.rapid.NodeStatusChange;
+import com.vrg.rapid.ClusterStatusChange;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
@@ -26,7 +26,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
-import java.util.List;
 
 /**
  * Rapid Cluster example.
@@ -65,22 +64,22 @@ public class StandaloneAgent {
     /**
      * Executed whenever a Cluster VIEW_CHANGE_PROPOSAL event occurs.
      */
-    void onViewChangeProposal(final Long configurationId, final List<NodeStatusChange> viewChange) {
-        LOG.info("The condition detector has outputted a proposal: {} {}", viewChange, configurationId);
+    void onViewChangeProposal(final ClusterStatusChange viewChange) {
+        LOG.info("The condition detector has outputted a proposal: {}", viewChange);
     }
 
     /**
      * Executed whenever a Cluster KICKED event occurs.
      */
-    void onKicked(final Long configurationId, final List<NodeStatusChange> viewChange) {
-        LOG.info("We got kicked from the network: {} {}", viewChange, configurationId);
+    void onKicked(final ClusterStatusChange viewChange) {
+        LOG.info("We got kicked from the network: {}", viewChange);
     }
 
     /**
      * Executed whenever a Cluster VIEW_CHANGE event occurs.
      */
-    void onViewChange(final Long configurationId, final List<NodeStatusChange> viewChange) {
-        LOG.info("View change detected: {} {}", viewChange, configurationId);
+    void onViewChange(final ClusterStatusChange viewChange) {
+        LOG.info("View change detected: {}", viewChange);
     }
 
     /**

--- a/rapid/src/main/java/com/vrg/rapid/Cluster.java
+++ b/rapid/src/main/java/com/vrg/rapid/Cluster.java
@@ -48,7 +48,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
-import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
 /**
  * The public API for Rapid. Users create Cluster objects using either Cluster.start()
@@ -135,7 +135,7 @@ public final class Cluster {
      * @param callback Callback to be executed when {@code event} occurs.
      */
     public void registerSubscription(final ClusterEvents event,
-                                     final BiConsumer<Long, List<NodeStatusChange>> callback) {
+                                     final Consumer<ClusterStatusChange> callback) {
         membershipService.registerSubscription(event, callback);
     }
 
@@ -164,7 +164,7 @@ public final class Cluster {
         @Nullable private IEdgeFailureDetectorFactory edgeFailureDetector = null;
         private Metadata metadata = Metadata.getDefaultInstance();
         private Settings settings = new Settings();
-        private final Map<ClusterEvents, List<BiConsumer<Long, List<NodeStatusChange>>>> subscriptions =
+        private final Map<ClusterEvents, List<Consumer<ClusterStatusChange>>> subscriptions =
                 new EnumMap<>(ClusterEvents.class);
 
         // These fields are initialized at the beginning of start() and join()
@@ -223,7 +223,7 @@ public final class Cluster {
          */
         @ExperimentalApi
         public Builder addSubscription(final ClusterEvents event,
-                                       final BiConsumer<Long, List<NodeStatusChange>> callback) {
+                                       final Consumer<ClusterStatusChange> callback) {
             this.subscriptions.computeIfAbsent(event, k -> new ArrayList<>());
             this.subscriptions.get(event).add(callback);
             return this;

--- a/rapid/src/main/java/com/vrg/rapid/ClusterStatusChange.java
+++ b/rapid/src/main/java/com/vrg/rapid/ClusterStatusChange.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2016 - 2020 VMware, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the “License”); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an “AS IS” BASIS, without warranties or conditions of any kind,
+ * EITHER EXPRESS OR IMPLIED. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.vrg.rapid;
+
+import com.vrg.rapid.pb.Endpoint;
+
+import java.util.List;
+
+public class ClusterStatusChange {
+    private final long configurationId;
+    private final List<Endpoint> membership;
+    private final List<NodeStatusChange> delta;
+
+    public ClusterStatusChange(final long configurationId, final List<Endpoint> membership,
+                               final List<NodeStatusChange> delta) {
+        this.configurationId = configurationId;
+        this.membership = membership;
+        this.delta = delta;
+    }
+
+    /**
+     * @return the configuration ID represented by the this change event
+     */
+    public long getConfigurationId() {
+        return configurationId;
+    }
+
+    /**
+     * @return the membership in the configuration corresponding to getConfigurationId()
+     */
+    public List<Endpoint> getMembership() {
+        return membership;
+    }
+
+    /**
+     * @return the delta corresponding to this event
+     */
+    public List<NodeStatusChange> getDelta() {
+        return delta;
+    }
+
+    @Override
+    public String toString() {
+        return "ClusterStatusChange{" +
+                "configurationId=" + configurationId +
+                ", membership=" + membership +
+                ", delta=" + delta +
+                '}';
+    }
+}

--- a/rapid/src/main/java/com/vrg/rapid/messaging/impl/GrpcClient.java
+++ b/rapid/src/main/java/com/vrg/rapid/messaging/impl/GrpcClient.java
@@ -159,7 +159,7 @@ public class GrpcClient implements IMessagingClient {
 
     private Channel getChannel(final Endpoint remote) {
         // TODO: allow configuring SSL/TLS
-        Channel channel;
+        final Channel channel;
         LOG.debug("Creating channel from {} to {}", address, remote);
 
         if (settings.getUseInProcessTransport()) {


### PR DESCRIPTION
Previously, all subscriptions were callbacks with the signature
`BiConsumer<Long, List<NodeStatusChange>>`. This API was used to
present a configuration ID and a corresponding delta to the
caller. Depending on the kind of `ClusterEvent`, the delta was
either the proposed delta (for VIEW_CHANGE_PROPOSAL events),
or the delta that was just applied (for VIEW_CHANGE events).

This commit changes the subscription callback signatures to
`Consumer<ClusterStatusChange>`. A `ClusterStatusChange` object
exposes the configuration ID and delta like before, but
also supplies the full list of Endpoints that are part
of the configuration ID.

Signed-off-by: Lalith Suresh <lsuresh@vmware.com>