### PR TITLE
FYI: changes made to integrate with Apache Geode

### DIFF
--- a/rapid/src/main/java/com/vrg/rapid/MembershipService.java
+++ b/rapid/src/main/java/com/vrg/rapid/MembershipService.java
@@ -210,9 +210,10 @@ public final class MembershipService {
                     .setSender(myAddr)
                     .setConfigurationId(membershipView.getCurrentConfigurationId())
                     .setStatusCode(statusCode);
-            LOG.info("Join at seed for {seed:{}, sender:{}, config:{}, size:{}}",
+            LOG.info("Join at seed for {seed:{}, sender:{}, config:{}, size:{} members:{}}",
                     Utils.loggable(myAddr), Utils.loggable(msg.getSender()),
-                    membershipView.getCurrentConfigurationId(), membershipView.getMembershipSize());
+                    membershipView.getCurrentConfigurationId(), membershipView.getMembershipSize(),
+                    membershipView.getRing(0));
             if (statusCode.equals(JoinStatusCode.SAFE_TO_JOIN)
                     || statusCode.equals(JoinStatusCode.HOSTNAME_ALREADY_IN_RING)) {
                 // Return a list of observers for the joiner to contact for phase 2 of the protocol
@@ -527,12 +528,19 @@ public final class MembershipService {
     }
 
     /**
-     * Shuts down all the executors.
+     * Shuts down all the executors
      */
     void shutdown() {
         alertBatcherJob.cancel(true);
         failureDetectorJobs.forEach(k -> k.cancel(true));
-        messagingClient.shutdown();
+    }
+
+    /**
+     * Shuts down all the executors in preparation for a restart
+     */
+    void shutdownForRestart() {
+        alertBatcherJob.cancel(true);
+        failureDetectorJobs.forEach(k -> k.cancel(true));
     }
 
     /**


### PR DESCRIPTION
Here are the changes I made to integrate Rapid with Apache Geode.

The changes to Cluster were primarily to let me restart the Cluster using the same node identifier when I could detect that all other nodes were gone.  I needed a stable identifier in this case because Geode incorporates it into its own member identifiers.  Since the Messenger is started outside of Rapid and I needed to reuse it I made Rapid's shutdown of it optional.  It seems like Rapid shouldn't be doing that anyway since it's injected and may be used by the application for other purposes.

Aside from that I modified NettyClientServer to add an getter for its boundPort variable, which Geode needed for its member identifiers.


see the corresponding Apache Geode branch here:
repo: git@github.com:bschuchardt/geode.git
branch: feature/rapid_integration